### PR TITLE
feat: add Sherlockeye integration (search_sherlockeye)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,6 @@ ABUSEIPDB_API_KEY=your_key
 
 # Optional — GitHub profile/repo/email discovery (raises rate limit 60 → 5000 req/h)
 GITHUB_TOKEN=your_token
+
+# Optional — Sherlockeye Reverse Lookup & AI-Powered OSINT
+SHERLOCKEYE_API_KEY=your_key

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OpenOSINT/openosint",
   "title": "OpenOSINT",
-  "description": "AI-powered OSINT agent & MCP server. 16 tools: email, breach, IP, WHOIS, DNS, Shodan, GitHub & more.",
-  "version": "2.18.0",
+  "description": "AI-powered OSINT agent & MCP server. 17 tools: email, breach, IP, WHOIS, DNS, Shodan, Sherlockeye & more.",
+  "version": "2.19.0",
   "websiteUrl": "https://openosint.tech",
   "repository": {
     "url": "https://github.com/OpenOSINT/OpenOSINT",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "openosint",
-      "version": "2.18.0",
+      "version": "2.19.0",
       "transport": {
         "type": "stdio"
       },
@@ -50,6 +50,13 @@
         {
           "name": "ABUSEIPDB_API_KEY",
           "description": "AbuseIPDB API key for IP abuse reputation checks (search_abuseipdb tool)",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "SHERLOCKEYE_API_KEY",
+          "description": "Sherlockeye API key for Reverse Lookup & AI-Powered OSINT (search_sherlockeye tool)",
           "isRequired": false,
           "isSecret": true,
           "format": "string"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ OpenOSINT adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.19.0] — 2026-06-01
+
+### Added
+
+- **Sherlockeye integration** (`openosint/tools/search_sherlockeye.py`): new tool
+  `search_sherlockeye` that queries the Sherlockeye API for Reverse Lookup & AI-Powered OSINT
+  across email, phone, username, domain, IP, name, CPF, and CNPJ. Supports plain values
+  (type inferred), explicit `type:"value"` syntax, optional Deep Research via
+  `digital_accounts_expansion`, sync search with polling fallback, and formatted
+  aggregated results. Requires `SHERLOCKEYE_API_KEY`. Available as CLI subcommand
+  `openosint sherlockeye QUERY [--deep-research] [-t SECONDS]`, in the AI agent tool
+  loop, MCP server, and web UI.
+
+### Changed
+
+- Version bumped to 2.19.0.
+- Agent SYSTEM_PROMPT updated with Sherlockeye usage guidance.
+- MCP server docstring updated to reflect 17 tools.
+
+---
+
 ## [2.15.0] — 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Store all keys in a `.env` file at the project root (copy `.env.example`). `pyth
 | `CENSYS_API_ID` + `CENSYS_SECRET` | `search_censys` | Optional | Censys Search API — [get one](https://censys.io/account) |
 | `ABUSEIPDB_API_KEY` | `search_abuseipdb` | Optional | AbuseIPDB v2 — [get one](https://www.abuseipdb.com/account/api) |
 | `GITHUB_TOKEN` | `search_github` | Optional | GitHub API — raises rate limit from 60 to 5000 req/h — [get one](https://github.com/settings/tokens) |
+| `SHERLOCKEYE_API_KEY` | `search_sherlockeye` | Optional | Sherlockeye API — [get one](https://app.sherlockeye.io/api) |
 
 **Optional Python packages:**
 
@@ -129,6 +130,7 @@ Store all keys in a `.env` file at the project root (copy `.env.example`). `pyth
 | `search_abuseipdb` | AbuseIPDB v2 API | IP abuse reputation: confidence score, reports, country, ISP |
 | `search_github` | GitHub REST API | Profile, repos, commit-discovered emails, username/keyword search |
 | `search_dns` | dnspython (built-in) | A/AAAA/MX/NS/TXT/CNAME/SOA records; SPF, DMARC, DKIM analysis |
+| `search_sherlockeye` | Sherlockeye API | Reverse Lookup & AI-Powered OSINT: email, phone, IP, username, domain, CPF/CNPJ |
 
 ### search_email
 
@@ -509,6 +511,7 @@ Set `ANTHROPIC_API_KEY` (and optionally `HIBP_API_KEY`, `IPINFO_TOKEN`) in a `.e
 | Censys | https://censys.io | `search_censys` | Community |
 | AbuseIPDB | https://www.abuseipdb.com | `search_abuseipdb` | Community |
 | GitHub    | https://github.com        | `search_github`    | Community |
+| Sherlockeye | https://sherlockeye.io  | `search_sherlockeye` | Community |
 
 ## Sponsor this project
 

--- a/openosint/__init__.py
+++ b/openosint/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.18.0"
+__version__ = "2.19.0"
 version = __version__

--- a/openosint/agent.py
+++ b/openosint/agent.py
@@ -29,6 +29,7 @@ from openosint.tools.search_dns import run_dns_osint
 from openosint.tools.search_domain import run_domain_osint
 from openosint.tools.search_email import run_email_osint
 from openosint.tools.search_github import run_github_osint
+from openosint.tools.search_sherlockeye import run_sherlockeye_osint
 from openosint.tools.search_ip import run_ip_osint
 from openosint.tools.search_ip2location import run_ip2location_osint
 from openosint.tools.search_paste import run_paste_osint
@@ -303,6 +304,38 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "required": ["domain"],
         },
     },
+    {
+        "name": "search_sherlockeye",
+        "description": (
+            "Reverse Lookup & AI-Powered OSINT search via Sherlockeye for email, phone, username, "
+            "domain, IP, name, CPF, or CNPJ. Accepts a plain value (type inferred) or "
+            "explicit type:\"value\" (e.g. email:\"user@example.com\"). Returns aggregated "
+            "findings from Sherlockeye data sources. Use for broad identity pivots when you "
+            "need enriched cross-source results beyond holehe/sherlock alone. "
+            "Set deep_research=true for email/phone/name to enable digital account expansion. "
+            "Requires SHERLOCKEYE_API_KEY."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Target value or type:\"value\" (email, phone, name, domain, ip, "
+                        "username, cpf, cnpj)."
+                    ),
+                },
+                "deep_research": {
+                    "type": "boolean",
+                    "description": (
+                        "Enable Deep Research (digital_accounts_expansion) for email, phone, "
+                        "or name searches."
+                    ),
+                },
+            },
+            "required": ["query"],
+        },
+    },
 ]
 
 # ---------------------------------------------------------------------------
@@ -326,6 +359,11 @@ _TOOL_MAP: dict[str, Any] = {
     "search_abuseipdb": lambda a: run_abuseipdb_osint(a["ip"], timeout_seconds=30),
     "search_github": lambda a: run_github_osint(a["query"], timeout_seconds=30),
     "search_dns": lambda a: run_dns_osint(a["domain"], timeout_seconds=10),
+    "search_sherlockeye": lambda a: run_sherlockeye_osint(
+        a["query"],
+        timeout_seconds=120,
+        deep_research=bool(a.get("deep_research", False)),
+    ),
 }
 
 SYSTEM_PROMPT = """You are OpenOSINT, an expert OSINT analyst assistant running in a terminal.
@@ -338,6 +376,8 @@ INVESTIGATION STRATEGY:
 - For an IP: run search_ip and optionally search_shodan or search_censys for open ports/services.
 - For a GitHub username or handle: use search_github to retrieve profile data, repos, and commit-discovered emails.
 - For IP reputation/abuse: use search_abuseipdb to get the abuseConfidenceScore — a score above 50% indicates a high-risk IP; combine with search_ip or search_shodan for full context.
+- For broad identity pivots (email, phone, name, username, domain, IP, CPF, CNPJ): use search_sherlockeye for Reverse Lookup & AI-Powered OSINT enriched results; prefer search_email/search_username for fast platform enumeration, then search_sherlockeye for deeper cross-source enrichment.
+- Use search_sherlockeye with deep_research=true only for email, phone, or name when the user wants linked digital accounts and social profiles.
 - For a domain or IP infrastructure: use search_censys for certificate history and port data.
 - For a Shodan query or banners: use search_shodan.
 - Chain tools intelligently: use findings from each step to decide the next.

--- a/openosint/cli.py
+++ b/openosint/cli.py
@@ -37,6 +37,7 @@ from openosint.tools.search_censys import run_censys_osint  # noqa: E402
 from openosint.tools.search_dns import run_dns_osint  # noqa: E402
 from openosint.tools.search_email import run_email_osint  # noqa: E402
 from openosint.tools.search_github import run_github_osint  # noqa: E402
+from openosint.tools.search_sherlockeye import run_sherlockeye_osint  # noqa: E402
 from openosint.tools.search_ip2location import run_ip2location_osint  # noqa: E402
 from openosint.tools.search_paste import run_paste_osint  # noqa: E402
 from openosint.tools.search_shodan import run_shodan_osint  # noqa: E402
@@ -321,6 +322,31 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Request timeout (default: 30).",
     )
 
+    # sherlockeye
+    sherlockeye_cmd = subparsers.add_parser(
+        "sherlockeye",
+        help="Sherlockeye Reverse Lookup & AI-Powered OSINT search (no AI). Requires SHERLOCKEYE_API_KEY.",
+    )
+    sherlockeye_cmd.add_argument(
+        "query",
+        type=str,
+        metavar="QUERY",
+        help='Target value or type:"value" (email, phone, name, domain, ip, username, cpf, cnpj).',
+    )
+    sherlockeye_cmd.add_argument(
+        "--deep-research",
+        action="store_true",
+        help="Enable Deep Research (digital_accounts_expansion) for email/phone/name.",
+    )
+    sherlockeye_cmd.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        default=120,
+        metavar="SECONDS",
+        help="Search timeout (default: 120).",
+    )
+
     # ip2location
     ip2location_cmd = subparsers.add_parser(
         "ip2location",
@@ -580,6 +606,24 @@ async def _handle_dns(
         _print_result(result)
 
 
+async def _handle_sherlockeye(
+    query: str,
+    timeout: int,
+    deep_research: bool = False,
+    json_output: bool = False,
+) -> None:
+    print(f"[*] Sherlockeye search: {query}", file=sys.stderr)
+    result = await run_sherlockeye_osint(
+        query=query,
+        timeout_seconds=timeout,
+        deep_research=deep_research,
+    )
+    if json_output:
+        _emit_json(format_tool_result("search_sherlockeye", query, result))
+    else:
+        _print_result(result)
+
+
 async def _handle_ip2location(
     ip: str,
     timeout: int,
@@ -764,6 +808,13 @@ async def _async_main() -> None:
         await _handle_dns(args.domain, args.timeout, json_output=json_output)
     elif args.command == "abuseipdb":
         await _handle_abuseipdb(args.ip, args.timeout, json_output=json_output)
+    elif args.command == "sherlockeye":
+        await _handle_sherlockeye(
+            args.query,
+            args.timeout,
+            deep_research=getattr(args, "deep_research", False),
+            json_output=json_output,
+        )
     elif args.command == "ip2location":
         await _handle_ip2location(args.ip, args.timeout, json_output=json_output)
     elif args.command == "multi":

--- a/openosint/mcp_server.py
+++ b/openosint/mcp_server.py
@@ -1,13 +1,13 @@
 # openosint/mcp_server.py
 """
-OpenOSINT MCP Server — v2.18.0
+OpenOSINT MCP Server — v2.19.0
 
-Exposes all 16 OSINT tool capabilities plus multi-target investigation
+Exposes all 17 OSINT tool capabilities plus multi-target investigation
 to MCP-compliant AI clients over standard I/O. Tools include:
 search_email, search_username, search_breach, search_whois, search_ip,
 search_domain, generate_dorks, search_paste, search_phone, search_shodan,
 search_virustotal, search_censys, search_ip2location, search_abuseipdb,
-search_github, search_dns.
+search_github, search_dns, search_sherlockeye.
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ from openosint.tools.search_phone import run_phone_osint
 from openosint.tools.search_shodan import run_shodan_osint
 from openosint.tools.search_username import run_username_osint
 from openosint.tools.search_virustotal import run_virustotal_osint
+from openosint.tools.search_sherlockeye import run_sherlockeye_osint
 from openosint.tools.search_whois import run_whois_osint
 
 logging.basicConfig(level=logging.INFO, format="[MCP] %(levelname)s: %(message)s")
@@ -256,6 +257,28 @@ async def list_tools() -> list[Tool]:
             ),
         ),
         Tool(
+            name="search_sherlockeye",
+            description=(
+                "Reverse Lookup & AI-Powered OSINT search via Sherlockeye for email, phone, username, "
+                "domain, IP, name, CPF, or CNPJ. Accepts plain values (type inferred) or "
+                "type:\"value\" syntax. Set deep_research=true for digital account expansion "
+                "on email/phone/name. Requires SHERLOCKEYE_API_KEY env var."
+            ),
+            inputSchema=_with_json(
+                {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "deep_research": {
+                            "type": "boolean",
+                            "description": "Enable digital_accounts_expansion module.",
+                        },
+                    },
+                    "required": ["query"],
+                }
+            ),
+        ),
+        Tool(
             name="investigate_multi",
             description=(
                 "Investigate multiple targets in parallel using the full OSINT tool chain. "
@@ -336,6 +359,14 @@ _HANDLERS: dict[str, tuple] = {
     "search_dns": (
         lambda a: run_dns_osint(a["domain"], timeout_seconds=10),
         lambda a: a["domain"],
+    ),
+    "search_sherlockeye": (
+        lambda a: run_sherlockeye_osint(
+            a["query"],
+            timeout_seconds=120,
+            deep_research=bool(a.get("deep_research", False)),
+        ),
+        lambda a: a["query"],
     ),
 }
 

--- a/openosint/repl.py
+++ b/openosint/repl.py
@@ -58,6 +58,7 @@ _TOOL_INFO_ROWS = [
     ("search_abuseipdb", "AbuseIPDB API", "IP abuse confidence score"),
     ("search_github", "GitHub API", "Profile, repos, commit-email discovery"),
     ("search_dns", "dnspython", "DNS records & email security audit"),
+    ("search_sherlockeye", "Sherlockeye API", "Reverse Lookup & AI-Powered OSINT (email, phone, IP, etc.)"),
 ]
 
 # ---------------------------------------------------------------------------

--- a/openosint/tools/search_sherlockeye.py
+++ b/openosint/tools/search_sherlockeye.py
@@ -1,0 +1,282 @@
+# openosint/tools/search_sherlockeye.py
+"""
+Sherlockeye integration module.
+
+Reverse Lookup & AI-Powered OSINT search across email, phone, username, domain,
+IP, name, CPF, and CNPJ via the Sherlockeye API. Uses synchronous search
+with polling fallback when the API returns a processing status.
+Requires SHERLOCKEYE_API_KEY.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.sherlockeye.io"
+_DEFAULT_TIMEOUT = 120
+_POLL_INTERVAL = 5
+_MAX_RESULTS_DISPLAY = 50
+
+_MISSING_KEY_ERROR = (
+    "Scan error: SHERLOCKEYE_API_KEY environment variable is not set. "
+    "Get a key at https://app.sherlockeye.io/api"
+)
+
+_EXPLICIT_QUERY_RE = re.compile(
+    r"^(email|phone|name|domain|ip|username|cpf|cnpj)\s*:\s*(?:\"([^\"]+)\"|(.+))$",
+    re.IGNORECASE,
+)
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_IP_RE = re.compile(
+    r"^("
+    r"(\d{1,3}\.){3}\d{1,3}"
+    r"|"
+    r"([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}"
+    r")$"
+)
+_DOMAIN_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z]{2,})+$")
+_PHONE_RE = re.compile(r"^\+?[\d\s().\-]{8,20}$")
+_CPF_RE = re.compile(r"^\d{11}$")
+_CNPJ_RE = re.compile(r"^\d{14}$")
+
+_TERMINAL_STATUSES = frozenset({"complete", "completed", "failed", "partial"})
+
+
+def _digits_only(value: str) -> str:
+    return re.sub(r"\D", "", value)
+
+
+def _infer_search_type(value: str) -> str:
+    stripped = value.strip()
+    lowered = stripped.lower()
+    if _EMAIL_RE.match(lowered):
+        return "email"
+    if _IP_RE.match(stripped):
+        return "ip"
+    digits = _digits_only(stripped)
+    if _CPF_RE.match(digits):
+        return "cpf"
+    if _CNPJ_RE.match(digits):
+        return "cnpj"
+    if _PHONE_RE.match(stripped) and len(digits) >= 8:
+        return "phone"
+    if _DOMAIN_RE.match(lowered) and "@" not in lowered:
+        return "domain"
+    if " " in stripped:
+        return "name"
+    return "username"
+
+
+def _parse_query(query: str) -> tuple[str, str]:
+    query = query.strip()
+    if not query:
+        raise ValueError("Query cannot be empty.")
+    match = _EXPLICIT_QUERY_RE.match(query)
+    if match:
+        search_type = match.group(1).lower()
+        value = (match.group(2) or match.group(3) or "").strip()
+        if not value:
+            raise ValueError("Query value cannot be empty.")
+        return search_type, value
+    return _infer_search_type(query), query
+
+
+def _build_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _raise_for_api_error(status: int, payload: dict | None) -> None:
+    message = "Unknown Sherlockeye API error."
+    if isinstance(payload, dict):
+        message = payload.get("message") or message
+    if status in (401, 403):
+        raise ValueError(f"Sherlockeye: invalid API key or access denied — {message}")
+    if status == 429:
+        raise ValueError(f"Sherlockeye: rate limit or credits exceeded — {message}")
+    if status in (400, 422):
+        raise ValueError(f"Sherlockeye: invalid request — {message}")
+    if status >= 500:
+        raise ValueError(f"Sherlockeye server error (HTTP {status}) — {message}")
+    if status != 200:
+        raise ValueError(f"Sherlockeye returned HTTP {status} — {message}")
+
+
+async def _api_request(
+    session: aiohttp.ClientSession,
+    method: str,
+    path: str,
+    *,
+    json_payload: dict | None = None,
+) -> dict:
+    url = f"{_API_BASE}{path}"
+    async with session.request(method, url, json=json_payload) as resp:
+        try:
+            body = await resp.json()
+        except aiohttp.ContentTypeError:
+            body = None
+        if resp.status >= 400:
+            _raise_for_api_error(resp.status, body if isinstance(body, dict) else None)
+        if not isinstance(body, dict):
+            raise ValueError("Sherlockeye returned an invalid JSON response.")
+        return body
+
+
+def _format_result_item(item: dict, index: int) -> list[str]:
+    source = item.get("source", "unknown")
+    attributes = item.get("attributes") or {}
+    lines = [f"  [{index}] Source: {source}"]
+    if attributes:
+        for key, val in list(attributes.items())[:12]:
+            lines.append(f"      {key}: {val}")
+    return lines
+
+
+def _format_search_response(data: dict, query_label: str) -> str:
+    status = data.get("status", "unknown")
+    search_type = data.get("type", "unknown")
+    value = data.get("value", query_label)
+    search_id = data.get("searchId", "")
+    progress = data.get("progress")
+    results = data.get("results") or []
+
+    lines = [
+        f"[Sherlockeye] Query: {value}",
+        f"[Sherlockeye] Type: {search_type}",
+        f"[Sherlockeye] Status: {status}",
+    ]
+    if search_id:
+        lines.append(f"[Sherlockeye] Search ID: {search_id}")
+    if progress is not None:
+        lines.append(f"[Sherlockeye] Progress: {progress}%")
+
+    if status in ("failed",):
+        lines.append("[Sherlockeye] Search failed — no results returned.")
+        return "\n".join(lines)
+
+    if not results:
+        if status in ("processing",):
+            lines.append(
+                "[Sherlockeye] Search still processing — try again later or increase timeout."
+            )
+        else:
+            lines.append("[Sherlockeye] No results found.")
+        return "\n".join(lines)
+
+    lines.append(f"\n[Sherlockeye] Results ({len(results)} item(s)):")
+    for idx, item in enumerate(results[:_MAX_RESULTS_DISPLAY], start=1):
+        if isinstance(item, dict):
+            lines.extend(_format_result_item(item, idx))
+    if len(results) > _MAX_RESULTS_DISPLAY:
+        lines.append(f"  … and {len(results) - _MAX_RESULTS_DISPLAY} more result(s) truncated.")
+    return "\n".join(lines)
+
+
+async def _create_sync_search(
+    session: aiohttp.ClientSession,
+    payload: dict,
+) -> dict:
+    response = await _api_request(session, "POST", "/v1/searches/sync", json_payload=payload)
+    return response.get("data", {})
+
+
+async def _create_async_search(
+    session: aiohttp.ClientSession,
+    payload: dict,
+) -> dict:
+    response = await _api_request(session, "POST", "/v1/searches", json_payload=payload)
+    return response.get("data", {})
+
+
+async def _get_search(session: aiohttp.ClientSession, search_id: str) -> dict:
+    response = await _api_request(session, "GET", f"/v1/searches/{search_id}")
+    return response.get("data", {})
+
+
+async def _poll_until_done(
+    session: aiohttp.ClientSession,
+    search_id: str,
+    deadline: float,
+) -> dict:
+    while True:
+        data = await _get_search(session, search_id)
+        status = (data.get("status") or "").lower()
+        if status in _TERMINAL_STATUSES:
+            return data
+        if asyncio.get_running_loop().time() >= deadline:
+            return data
+        await asyncio.sleep(_POLL_INTERVAL)
+
+
+async def run_sherlockeye_osint(
+    query: str,
+    timeout_seconds: int = _DEFAULT_TIMEOUT,
+    deep_research: bool = False,
+) -> str:
+    """
+    Run a Sherlockeye reverse OSINT search for *query*.
+
+  Parameters
+    ----------
+    query
+        Plain value (type inferred) or explicit ``type:"value"`` / ``type:value``.
+    timeout_seconds
+        Maximum wait time for sync search and polling fallback.
+    deep_research
+        When True, enables ``digital_accounts_expansion`` for email/phone/name.
+    """
+    api_key = os.environ.get("SHERLOCKEYE_API_KEY", "")
+    if not api_key:
+        return _MISSING_KEY_ERROR
+
+    try:
+        search_type, value = _parse_query(query)
+    except ValueError as exc:
+        return f"Scan error: {exc}"
+
+    payload: dict = {"type": search_type, "value": value, "timeoutSeconds": timeout_seconds}
+    if deep_research:
+        payload["additional_modules"] = ["digital_accounts_expansion"]
+
+    timeout_cfg = aiohttp.ClientTimeout(total=timeout_seconds + 30)
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+
+    try:
+        async with aiohttp.ClientSession(
+            headers=_build_headers(api_key),
+            timeout=timeout_cfg,
+        ) as session:
+            data = await _create_sync_search(session, payload)
+            status = (data.get("status") or "").lower()
+
+            if status == "processing" and data.get("searchId"):
+                data = await _poll_until_done(session, data["searchId"], deadline)
+
+            if status == "processing" and not data.get("results"):
+                async_payload = {k: v for k, v in payload.items() if k != "timeoutSeconds"}
+                created = await _create_async_search(session, async_payload)
+                search_id = created.get("searchId")
+                if search_id:
+                    data = await _poll_until_done(session, search_id, deadline)
+
+            return _format_search_response(data, query)
+
+    except asyncio.TimeoutError:
+        return f"Scan error: Sherlockeye request timed out after {timeout_seconds}s."
+    except aiohttp.ClientError as exc:
+        return f"Scan error: Network error querying Sherlockeye: {exc}"
+    except ValueError as exc:
+        return f"Scan error: {exc}"
+    except Exception as exc:
+        logger.exception("Unexpected error during Sherlockeye lookup.")
+        return f"Internal error: {exc}"

--- a/openosint/web_server.py
+++ b/openosint/web_server.py
@@ -51,9 +51,10 @@ from openosint.tools.search_phone import run_phone_osint
 from openosint.tools.search_shodan import run_shodan_osint
 from openosint.tools.search_username import run_username_osint
 from openosint.tools.search_virustotal import run_virustotal_osint
+from openosint.tools.search_sherlockeye import run_sherlockeye_osint
 from openosint.tools.search_whois import run_whois_osint
 
-_VERSION = "2.18.0"
+_VERSION = "2.19.0"
 _ROOT = Path(__file__).parent.parent
 
 # Web assets: prefer the package-relative path (pip install) with project-root fallback (dev/editable)
@@ -207,6 +208,17 @@ _TOOL_CATALOG: list[dict] = [
         "requires_env": ["VIRUSTOTAL_API_KEY"],
         "env_hints": {"VIRUSTOTAL_API_KEY": "virustotal.com/gui/my-apikey"},
     },
+    {
+        "name": "search_sherlockeye",
+        "description": "Reverse Lookup & AI-Powered OSINT via Sherlockeye (email, phone, IP, username, etc.).",
+        "input_label": "Query (value or type:\"value\")",
+        "input_placeholder": "user@example.com",
+        "category": "Identity",
+        "icon": "🔎",
+        "requires_binary": [],
+        "requires_env": ["SHERLOCKEYE_API_KEY"],
+        "env_hints": {"SHERLOCKEYE_API_KEY": "app.sherlockeye.io/api"},
+    },
 ]
 
 # Map tool name → async callable(input_value: str, timeout: int) -> str
@@ -224,6 +236,7 @@ _RUNNERS: dict[str, object] = {
     "search_shodan": lambda v, t: run_shodan_osint(v, timeout_seconds=t),
     "search_virustotal": lambda v, t: run_virustotal_osint(v, timeout_seconds=t),
     "search_censys": lambda v, t: run_censys_osint(v, timeout_seconds=t),
+    "search_sherlockeye": lambda v, t: run_sherlockeye_osint(v, timeout_seconds=t),
 }
 
 # Claude tool schemas (one string "input" param per tool)
@@ -269,6 +282,7 @@ _KNOWN_ENV_KEYS = [
     "CENSYS_SECRET",
     "SHODAN_API_KEY",
     "VIRUSTOTAL_API_KEY",
+    "SHERLOCKEYE_API_KEY",
 ]
 
 

--- a/openosint_demo.py
+++ b/openosint_demo.py
@@ -30,6 +30,7 @@ _TOOLS: list[tuple[str, str, str, bool]] = [
     ("search_censys",      "Censys API",       "Certificates, ports, infrastructure",     True),
     ("search_ip2location", "IP2Location.io",   "Geoloc + VPN/Proxy/Tor  (sponsored)",    True),
     ("search_abuseipdb",   "AbuseIPDB API",    "Abuse reputation, confidence score",      True),
+    ("search_sherlockeye", "Sherlockeye API",  "Reverse Lookup & AI-Powered OSINT",              True),
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openosint"
-version = "2.18.0"
-description = "AI-powered OSINT agent, MCP server, and CLI. Interactive REPL + 16 tools. Anthropic Claude or local Ollama. For authorized security research use only."
+version = "2.19.0"
+description = "AI-powered OSINT agent, MCP server, and CLI. Interactive REPL + 17 tools. Anthropic Claude or local Ollama. For authorized security research use only."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"

--- a/tests/test_json_export.py
+++ b/tests/test_json_export.py
@@ -27,6 +27,7 @@ ALL_TOOLS = [
     "search_phone",
     "search_shodan",
     "search_virustotal",
+    "search_sherlockeye",
 ]
 
 

--- a/tests/test_sherlockeye.py
+++ b/tests/test_sherlockeye.py
@@ -1,0 +1,87 @@
+# tests/test_sherlockeye.py
+"""Tests for Sherlockeye integration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+
+from openosint.tools.search_sherlockeye import (
+    _infer_search_type,
+    _parse_query,
+    run_sherlockeye_osint,
+)
+
+
+def test_parse_explicit_email() -> None:
+    assert _parse_query('email:"user@example.com"') == ("email", "user@example.com")
+
+
+def test_parse_explicit_unquoted() -> None:
+    assert _parse_query("domain:example.com") == ("domain", "example.com")
+
+
+def test_infer_email() -> None:
+    assert _infer_search_type("user@example.com") == "email"
+
+
+def test_infer_ip() -> None:
+    assert _infer_search_type("8.8.8.8") == "ip"
+
+
+def test_infer_name() -> None:
+    assert _infer_search_type("John Doe") == "name"
+
+
+async def test_missing_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SHERLOCKEYE_API_KEY", raising=False)
+    result = await run_sherlockeye_osint("user@example.com")
+    assert "Scan error" in result
+    assert "SHERLOCKEYE_API_KEY" in result
+
+
+async def test_empty_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SHERLOCKEYE_API_KEY", "test-key")
+    result = await run_sherlockeye_osint("   ")
+    assert "Scan error" in result
+
+
+async def test_successful_sync_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SHERLOCKEYE_API_KEY", "test-key")
+    mock_data = {
+        "searchId": "abc123",
+        "type": "email",
+        "value": "user@example.com",
+        "status": "complete",
+        "progress": 100,
+        "results": [
+            {
+                "id": "1",
+                "source": "example_source",
+                "attributes": {"email": "user@example.com", "name": "User"},
+            }
+        ],
+    }
+    with patch(
+        "openosint.tools.search_sherlockeye._create_sync_search",
+        new_callable=AsyncMock,
+        return_value=mock_data,
+    ):
+        result = await run_sherlockeye_osint("user@example.com", timeout_seconds=30)
+    assert "[Sherlockeye]" in result
+    assert "example_source" in result
+    assert "user@example.com" in result
+
+
+async def test_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SHERLOCKEYE_API_KEY", "test-key")
+    with patch(
+        "openosint.tools.search_sherlockeye._create_sync_search",
+        new_callable=AsyncMock,
+        side_effect=aiohttp.ClientError("connection failed"),
+    ):
+        result = await run_sherlockeye_osint("8.8.8.8")
+    assert "Scan error" in result
+    assert "Network error" in result


### PR DESCRIPTION
## Summary

- Adds `search_sherlockeye`, integrating the Sherlockeye API for multi-source reverse OSINT (email, phone, username, domain, IP, name, CPF, CNPJ).
- Implements an async HTTP client (`aiohttp`) with sync search (`/v1/searches/sync`) and polling fallback when status stays in processing.
- Supports plain values with type inference, explicit `type:"value"` / `type:value` syntax, and optional Deep Research via `digital_accounts_expansion` (`deep_research` flag / `--deep-research` CLI).
- Registers the tool in the agent, MCP server, CLI, REPL, and web UI; documents `SHERLOCKEYE_API_KEY` in `.env.example`, README, and `.mcp/server.json`.
- Bumps version to **2.19.0** and adds tests in `tests/test_sherlockeye.py`.

## Test plan

- [ ] Set `SHERLOCKEYE_API_KEY` in `.env`
- [ ] `openosint sherlockeye user@example.com`
- [ ] `openosint sherlockeye 'email:"user@example.com"' --deep-research -t 120`
- [ ] Verify `search_sherlockeye` via MCP / agent REPL
- [ ] `pytest tests/test_sherlockeye.py -q`