### PR TITLE
fix(utils): resolve binaries installed in the same venv/uv-tool bin

### DIFF
--- a/openosint/utils.py
+++ b/openosint/utils.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shutil
+import sys
+from pathlib import Path
 from typing import NamedTuple
 
 from openosint.tools.exceptions import ToolNotFoundError, ToolTimeoutError
@@ -54,9 +57,15 @@ async def run_subprocess(
     ToolTimeoutError
         When the process exceeds timeout_seconds.
     """
-    if not shutil.which(binary):
+    # Also search the directory where the current Python executable lives so that
+    # tools installed in the same venv or uv-tool bin directory are always found,
+    # even when that directory is not in the user's PATH.
+    venv_bin = str(Path(sys.executable).parent)
+    search_path = os.pathsep.join([venv_bin, os.environ.get("PATH", "")])
+    if not shutil.which(binary, path=search_path):
         detail = f" {install_hint}" if install_hint else ""
         raise ToolNotFoundError(f"'{binary}' is not installed or not in PATH.{detail}")
+    binary = shutil.which(binary, path=search_path) or binary
 
     process: asyncio.subprocess.Process | None = None
     try:


### PR DESCRIPTION
## Problem

When OpenOSINT is installed via `uv tool install`, it runs inside an isolated virtual environment. Tools like `holehe` or `phoneinfoga` can be installed into that same environment (e.g. `uv pip install holehe --python <venv-python>`), but `shutil.which()` only searches the system `PATH` — not the venv's `bin/` directory. This causes a spurious `ToolNotFoundError` even when the binary is present and working.

**Symptom:**
```
Email scan failed: 'holehe' is not installed or not in PATH. Install it with: pip install holehe
```

## Fix

Prepend the directory of the running Python executable (`sys.executable`) to the search path before calling `shutil.which()`. This ensures any binary co-installed in the same venv or uv-tool environment is always resolved, regardless of the user's system `PATH`.

```python
venv_bin = str(Path(sys.executable).parent)
search_path = os.pathsep.join([venv_bin, os.environ.get("PATH", "")])
binary = shutil.which(binary, path=search_path) or binary
```

## Impact

- No behaviour change when binaries are already on the system `PATH`.
- Fixes discovery for binaries installed inside the venv (common with `uv tool install`).
- Affects all tool wrappers that use `run_subprocess()` (`holehe`, `phoneinfoga`, `sherlock`, `sublist3r`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)