### PR TITLE
feat: add OpenAI-compatible backend support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,18 @@
 # Copy this file to .env and fill in your keys
 # Never commit .env to git
 
-# Required for AI REPL
+# AI backend — choose ONE of the following.
+#
+# 1) Anthropic Claude (default)
 ANTHROPIC_API_KEY=sk-ant-...
+#
+# 2) Any OpenAI-compatible endpoint (LiteLLM, llama-swap, vLLM, LM Studio, …).
+#    Set OPENAI_BASE_URL to enable.  Takes precedence over Ollama when no
+#    ANTHROPIC_API_KEY is set.  The model's server must support tool/function
+#    calling (e.g. llama.cpp launched with --jinja).
+# OPENAI_BASE_URL=http://localhost:4000/v1
+# OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o-mini
 
 # Optional — data breach checks
 HIBP_API_KEY=your_key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ OpenOSINT adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **OpenAI-compatible backend** (`--provider openai`). OpenOSINT can now drive any
+  endpoint that speaks the OpenAI `/v1/chat/completions` protocol — LiteLLM,
+  llama-swap, vLLM, LM Studio, etc. — via the new `OpenAICompatibleAgent`.
+  - CLI flags: `--openai-base-url`, `--openai-model`, `--openai-api-key`.
+  - Env vars: `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_MODEL`. When
+    `OPENAI_BASE_URL` is set (and no `ANTHROPIC_API_KEY`), it takes precedence
+    over Ollama.
+  - Web UI: new "OpenAI API" backend option with base-URL/model/key fields and a
+    connection test; streaming tool-use via the new `_stream_openai` handler.
+  - The target model must support tool/function calling (for llama.cpp behind
+    llama-swap, launch with `--jinja`).
+
 ## [2.18.1] — 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ mcp-name: io.github.OpenOSINT/openosint
 
 ## What is OpenOSINT?
 
-OpenOSINT is an AI agent for Open Source Intelligence with three interfaces: an interactive terminal REPL, a direct CLI, and an MCP server exposable to Claude Code, Claude Desktop, or any MCP-compatible client — plus a browser-based Web UI added in v2.12.0. The AI layer uses Anthropic's native tool use API (or a local Ollama model): the model issues hard stops when it needs a tool, your code executes the real binary, the actual output goes back — hallucination in tool results is structurally impossible.
+OpenOSINT is an AI agent for Open Source Intelligence with three interfaces: an interactive terminal REPL, a direct CLI, and an MCP server exposable to Claude Code, Claude Desktop, or any MCP-compatible client — plus a browser-based Web UI added in v2.12.0. The AI layer uses Anthropic's native tool use API (or a local Ollama model, or any OpenAI-compatible endpoint): the model issues hard stops when it needs a tool, your code executes the real binary, the actual output goes back — hallucination in tool results is structurally impossible.
 
 ## Features
 
 - **AI tool chaining** — the agent decides which of 16 tools to run, chains them based on findings, and compiles a structured report
 - **16 modular tools** covering email, username, breach, WHOIS, IP, subdomain, dorks, paste, phone, Shodan, VirusTotal, Censys, IP2Location, AbuseIPDB, GitHub, and DNS
-- **Anthropic + Ollama** — use Claude via API key or run fully offline with a local Ollama model
+- **Anthropic, Ollama, or any OpenAI-compatible endpoint** — use Claude via API key, run fully offline with a local Ollama model, or point at any OpenAI-compatible server (LiteLLM, llama-swap, vLLM, LM Studio, …)
 - **MCP server** — expose all tools natively to Claude Code and Claude Desktop
 - **Parallel execution** — `--parallel` runs complementary tools concurrently via `asyncio.gather()`
 - **PDF + Markdown reports** — auto-saved after every investigation; PDF export via `reportlab`
@@ -90,7 +90,10 @@ Store all keys in a `.env` file at the project root (copy `.env.example`). `pyth
 
 | Variable | Tool | Required | Purpose |
 |----------|------|----------|---------|
-| `ANTHROPIC_API_KEY` | AI agent | Yes (or use Ollama) | Anthropic API key |
+| `ANTHROPIC_API_KEY` | AI agent | Yes (or use Ollama / OpenAI) | Anthropic API key |
+| `OPENAI_BASE_URL` | AI agent | Optional | Base URL of an OpenAI-compatible endpoint (e.g. `http://localhost:4000/v1`). When set and `ANTHROPIC_API_KEY` is absent, it is used as the AI backend (takes precedence over Ollama). The model must support tool/function calling. |
+| `OPENAI_API_KEY` | AI agent | Optional | API key for the OpenAI-compatible endpoint (local servers may ignore it) |
+| `OPENAI_MODEL` | AI agent | Optional | Model name to request from the endpoint (default: `gpt-4o-mini`) |
 | `HIBP_API_KEY` | `search_breach` | Optional | HaveIBeenPwned v3 — [get one](https://haveibeenpwned.com/API/Key) |
 | `IPINFO_TOKEN` | `search_ip` | Optional | ipinfo.io higher rate limits |
 | `SHODAN_API_KEY` | `search_shodan` | Optional | Shodan API — [get one](https://account.shodan.io) |
@@ -105,6 +108,7 @@ Store all keys in a `.env` file at the project root (copy `.env.example`). `pyth
 | Package | Purpose | Install |
 |---------|---------|---------|
 | `ollama` | Local LLM backend (no API key) | `pip install ollama` *(Python client only — also install the [Ollama runtime](https://ollama.com))* |
+| `openai` | OpenAI-compatible backend for the REPL/CLI (`--provider openai`) | `pip install "openosint[openai]"` *(not required for the Web UI, which has no extra dependency)* |
 | `shodan` | Shodan API client | `pip install shodan` |
 | `reportlab` | PDF report export | `pip install reportlab` |
 | `censys` | Censys API client | `pip install censys` |
@@ -400,7 +404,7 @@ openosint web
 # Opens http://localhost:8080 automatically
 ```
 
-Browser-based AI chat interface with streaming tool output, inline result cards, light/dark theme toggle, and Ollama support for fully local inference. No API key required when using Ollama.
+Browser-based AI chat interface with streaming tool output, inline result cards, light/dark theme toggle, and support for fully local inference via Ollama or any OpenAI-compatible endpoint. No Anthropic API key required when using a local backend.
 
 ```bash
 # Install web extras
@@ -417,6 +421,23 @@ ollama pull llama3.2  # download the model (~2 GB)
 # Step 3: launch OpenOSINT and switch to Ollama
 openosint web
 # Settings -> Ollama (local) -> set model to llama3.2
+
+# Or point at any OpenAI-compatible endpoint (LiteLLM, llama-swap, vLLM, LM Studio, …).
+# The selected model must support tool/function calling.
+export OPENAI_BASE_URL="http://localhost:4000/v1"
+export OPENAI_API_KEY="sk-..."        # optional for local servers
+export OPENAI_MODEL="gpt-4o-mini"
+openosint web
+# Settings -> OpenAI API  (or just start chatting — it is auto-selected when no ANTHROPIC_API_KEY is set)
+```
+
+For the REPL/CLI, the same backend is available via `--provider openai`:
+
+```bash
+pip install "openosint[openai]"
+openosint --provider openai \
+  --openai-base-url http://localhost:4000/v1 \
+  --openai-model gpt-4o-mini
 ```
 
 <div align="center">
@@ -501,9 +522,12 @@ Set `ANTHROPIC_API_KEY` (and optionally `HIBP_API_KEY`, `IPINFO_TOKEN`) in a `.e
 | `--api-key KEY` | Anthropic API key (overrides env var) |
 | `--parallel` | Run complementary tools concurrently |
 | `--json` | Output results as structured JSON |
-| `--provider {anthropic,ollama}` | AI provider (default: `anthropic`) |
+| `--provider {anthropic,ollama,openai}` | AI provider (default: `anthropic`) |
 | `--ollama-model MODEL` | Ollama model name (default: `llama3.2`) |
 | `--ollama-host URL` | Ollama server URL (default: `http://localhost:11434`) |
+| `--openai-base-url URL` | OpenAI-compatible endpoint base URL (env: `OPENAI_BASE_URL`) |
+| `--openai-model MODEL` | Model to request from the endpoint (default: `gpt-4o-mini`; env: `OPENAI_MODEL`) |
+| `--openai-api-key KEY` | API key for the endpoint (env: `OPENAI_API_KEY`) |
 | `--no-pdf` | Disable automatic PDF generation |
 
 ## Integrations

--- a/openosint/agent.py
+++ b/openosint/agent.py
@@ -5,8 +5,10 @@ OpenOSINT AI Agent.
 Implements the agentic loop using either:
   - The Anthropic native tool use API (default, ``provider="anthropic"``).
   - A local Ollama model (``provider="ollama"``).
+  - Any OpenAI-compatible chat-completions endpoint (``provider="openai"``) —
+    LiteLLM, llama-swap, vLLM, LM Studio, etc.
 
-Both agents share the same ``run()`` interface and return an ``AgentResponse``.
+All agents share the same ``run()`` interface and return an ``AgentResponse``.
 No manual JSON parsing.  The model issues hard stops when it needs a tool,
 the real tool executes, the output goes back.  Hallucination in tool results
 is structurally impossible.
@@ -14,6 +16,7 @@ is structurally impossible.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -694,3 +697,160 @@ class OllamaAgent:
                 )
             logger.exception("Unexpected error in Ollama agent loop.")
             return AgentResponse(content="", error=err_str)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible agent  (LiteLLM, llama-swap, vLLM, LM Studio, …)
+# ---------------------------------------------------------------------------
+
+
+# OpenAI and Ollama share the same function-tool schema.
+_OPENAI_TOOLS = _OLLAMA_TOOLS
+
+
+def _build_openai_assistant_message(msg: Any) -> dict[str, Any]:
+    """Serialize an OpenAI assistant message with tool_calls into history dict form."""
+    return {
+        "role": "assistant",
+        "content": msg.content or "",
+        "tool_calls": [
+            {
+                "id": openai_tool_call.id,
+                "type": "function",
+                "function": {
+                    "name": openai_tool_call.function.name,
+                    "arguments": openai_tool_call.function.arguments,
+                },
+            }
+            for openai_tool_call in msg.tool_calls
+        ],
+    }
+
+
+async def _process_openai_tool_turn(ctx: _AgentRunContext, openai_msg: Any) -> None:
+    """Execute all tool calls from one OpenAI response and append results to messages."""
+    ctx.messages.append(_build_openai_assistant_message(openai_msg))
+    for openai_tool_call in openai_msg.tool_calls:
+        tool_name = openai_tool_call.function.name
+        raw_args = openai_tool_call.function.arguments
+        try:
+            tool_input = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+        except (json.JSONDecodeError, TypeError):
+            tool_input = {"input": raw_args}
+        result = await _execute_tool(tool_name, tool_input, ctx.on_tool_call)
+        ctx.tool_calls.append(ToolCall(name=tool_name, input=tool_input, result=result))
+        logger.info("OpenAI tool executed: %s → %d chars", tool_name, len(result))
+        ctx.messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": openai_tool_call.id,
+                "content": result,
+            }
+        )
+
+
+class OpenAICompatibleAgent:
+    """
+    Stateful OSINT agent backed by any OpenAI-compatible chat-completions API.
+
+    Works with gateways and local inference servers that speak the OpenAI
+    ``/v1/chat/completions`` protocol — LiteLLM, llama-swap, vLLM, LM Studio,
+    Ollama's ``/v1`` shim, etc.  Requires the ``openai`` Python library.
+
+    The agent follows the same tool-use loop as ``OpenOSINTAgent``:
+    tool_call → execute real binary → feed real output back → loop until done.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        base_url: str = "http://localhost:8080/v1",
+        api_key: str | None = None,
+    ) -> None:
+        self.model = model
+        self.base_url = base_url
+        # Many local servers ignore the key, but the SDK requires a non-empty string.
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "") or "sk-no-key-required"
+        self.history: list[dict[str, Any]] = []
+
+    def clear_history(self) -> None:
+        """Reset conversation memory."""
+        self.history = []
+
+    async def run(
+        self,
+        prompt: str,
+        on_tool_call: Any = None,
+    ) -> AgentResponse:
+        """
+        Execute one agent turn via an OpenAI-compatible endpoint.
+
+        Parameters
+        ----------
+        prompt:
+            User message or OSINT target description.
+        on_tool_call:
+            Optional async callback — same signature as ``OpenOSINTAgent.run``.
+
+        Returns
+        -------
+        AgentResponse
+            Final text response and list of tool calls made.
+        """
+        try:
+            import openai  # type: ignore
+        except ImportError:
+            return AgentResponse(
+                content="",
+                error=(
+                    "The 'openai' Python library is not installed.\n"
+                    "Install it with:  pip install openai\n\n"
+                    "Then retry:  openosint --provider openai"
+                ),
+            )
+
+        self.history.append({"role": "user", "content": prompt})
+        messages: list[Any] = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            *self.history,
+        ]
+        ctx = _AgentRunContext(messages=messages, tool_calls=[], on_tool_call=on_tool_call)
+
+        try:
+            client = openai.AsyncOpenAI(base_url=self.base_url, api_key=self.api_key)
+            while True:
+                response = await client.chat.completions.create(
+                    model=self.model,
+                    messages=ctx.messages,
+                    tools=_OPENAI_TOOLS,
+                    tool_choice="auto",
+                    max_tokens=_MAX_TOKENS,
+                )
+                msg = response.choices[0].message
+                if not msg.tool_calls:
+                    text = msg.content or ""
+                    self.history.append({"role": "assistant", "content": text})
+                    return AgentResponse(content=text, tool_calls=ctx.tool_calls)
+                await _process_openai_tool_turn(ctx, msg)
+        except openai.AuthenticationError:
+            return AgentResponse(
+                content="",
+                error=(
+                    f"Authentication failed for the OpenAI-compatible endpoint at "
+                    f"{self.base_url}.  Check your API key (OPENAI_API_KEY)."
+                ),
+            )
+        except openai.APIConnectionError:
+            return AgentResponse(
+                content="",
+                error=(
+                    f"[ERROR] Cannot reach the OpenAI-compatible server at {self.base_url}\n\n"
+                    "Verify the base URL is correct and the server is running, e.g.:\n"
+                    "  openosint --provider openai \\\n"
+                    "    --openai-base-url http://localhost:4000/v1 \\\n"
+                    "    --openai-model gpt-4o-mini"
+                ),
+            )
+        except Exception as exc:
+            logger.exception("Unexpected error in OpenAI-compatible agent loop.")
+            return AgentResponse(content="", error=str(exc))

--- a/openosint/cli.py
+++ b/openosint/cli.py
@@ -28,6 +28,7 @@ import argparse  # noqa: E402
 import asyncio  # noqa: E402
 import json  # noqa: E402
 import logging  # noqa: E402
+import os  # noqa: E402
 import sys  # noqa: E402
 
 from openosint.json_output import format_tool_result  # noqa: E402
@@ -139,7 +140,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--provider",
         type=str,
         default="anthropic",
-        choices=["anthropic", "ollama"],
+        choices=["anthropic", "ollama", "openai"],
         help="AI provider for the interactive REPL (default: anthropic).",
     )
     parser.add_argument(
@@ -155,6 +156,37 @@ def _build_parser() -> argparse.ArgumentParser:
         default="http://localhost:11434",
         metavar="URL",
         help="Ollama server URL (default: http://localhost:11434).",
+    )
+    parser.add_argument(
+        "--openai-base-url",
+        type=str,
+        default=os.environ.get("OPENAI_BASE_URL", "http://localhost:8080/v1"),
+        metavar="URL",
+        help=(
+            "Base URL of an OpenAI-compatible endpoint (LiteLLM, llama-swap, vLLM, …).  "
+            "Used when --provider openai.  Default: $OPENAI_BASE_URL or "
+            "http://localhost:8080/v1."
+        ),
+    )
+    parser.add_argument(
+        "--openai-model",
+        type=str,
+        default=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+        metavar="MODEL",
+        help=(
+            "Model name to request from the OpenAI-compatible endpoint.  "
+            "Used when --provider openai.  Default: $OPENAI_MODEL or gpt-4o-mini."
+        ),
+    )
+    parser.add_argument(
+        "--openai-api-key",
+        type=str,
+        default=None,
+        metavar="KEY",
+        help=(
+            "API key for the OpenAI-compatible endpoint.  "
+            "Falls back to $OPENAI_API_KEY (local servers may ignore it)."
+        ),
     )
     parser.add_argument(
         "--no-pdf",
@@ -735,6 +767,9 @@ async def _async_main() -> None:
             provider=getattr(args, "provider", "anthropic"),
             ollama_model=getattr(args, "ollama_model", "llama3.2"),
             ollama_host=getattr(args, "ollama_host", "http://localhost:11434"),
+            openai_base_url=getattr(args, "openai_base_url", "http://localhost:8080/v1"),
+            openai_model=getattr(args, "openai_model", "gpt-4o-mini"),
+            openai_api_key=getattr(args, "openai_api_key", None),
             is_pdf_disabled=getattr(args, "is_pdf_disabled", False),
         )
         await repl.run()

--- a/openosint/repl.py
+++ b/openosint/repl.py
@@ -31,7 +31,7 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 
 from openosint import __version__
-from openosint.agent import OllamaAgent, OpenOSINTAgent
+from openosint.agent import OllamaAgent, OpenAICompatibleAgent, OpenOSINTAgent
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +85,8 @@ PROMPT_STYLE = Style.from_dict(
 def _print_banner(provider: str, model: str) -> None:
     if provider == "ollama":
         provider_info = f"[dim]Provider: Ollama ({model})[/]"
+    elif provider == "openai":
+        provider_info = f"[dim]Provider: OpenAI-compatible ({model})[/]"
     else:
         provider_info = f"[dim]Provider: Anthropic ({model})[/]"
 
@@ -194,6 +196,7 @@ def _print_config(
     model: str,
     ollama_host: str,
     is_pdf_disabled: bool,
+    openai_base_url: str = "",
 ) -> None:
     masked = ("*" * 20 + api_key[-6:]) if api_key and len(api_key) > 6 else "not set"
     rows = [
@@ -202,6 +205,8 @@ def _print_config(
     ]
     if provider == "anthropic":
         rows.append(f"[bold]API Key:[/]  {masked}")
+    elif provider == "openai":
+        rows.append(f"[bold]Endpoint:[/] {openai_base_url}")
     else:
         rows.append(f"[bold]Ollama:[/]   {ollama_host}")
     rows += [
@@ -248,20 +253,34 @@ class OpenOSINTRepl:
         provider: str = "anthropic",
         ollama_model: str = "llama3.2",
         ollama_host: str = "http://localhost:11434",
+        openai_base_url: str = "http://localhost:8080/v1",
+        openai_model: str = "gpt-4o-mini",
+        openai_api_key: str | None = None,
         is_pdf_disabled: bool = False,
     ) -> None:
         self._api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
         self._provider = provider
         self._ollama_model = ollama_model
         self._ollama_host = ollama_host
+        self._openai_base_url = openai_base_url
+        self._openai_model = openai_model
+        self._openai_api_key = openai_api_key
         self._is_pdf_disabled = is_pdf_disabled
 
+        self._agent: OpenOSINTAgent | OllamaAgent | OpenAICompatibleAgent
         if provider == "ollama":
-            self._agent: OpenOSINTAgent | OllamaAgent = OllamaAgent(
+            self._agent = OllamaAgent(
                 model=ollama_model,
                 host=ollama_host,
             )
             self._display_model = ollama_model
+        elif provider == "openai":
+            self._agent = OpenAICompatibleAgent(
+                model=openai_model,
+                base_url=openai_base_url,
+                api_key=openai_api_key,
+            )
+            self._display_model = openai_model
         else:
             self._agent = OpenOSINTAgent(api_key=self._api_key)
             self._display_model = "claude-sonnet-4-20250514"
@@ -409,6 +428,7 @@ class OpenOSINTRepl:
                         self._display_model,
                         self._ollama_host,
                         self._is_pdf_disabled,
+                        self._openai_base_url,
                     )
                     continue
 

--- a/openosint/web/index.html
+++ b/openosint/web/index.html
@@ -151,6 +151,13 @@
               class="flex-1 px-3 py-2 rounded-md border text-xs font-medium transition-all">
         Ollama (local)
       </button>
+      <button @click="settings.chatModel = 'openai'; saveLocalSettings()"
+              :class="settings.chatModel === 'openai'
+                ? 'bg-border text-primary border-app'
+                : 'bg-app border-app text-secondary hover:border-app hover:text-primary'"
+              class="flex-1 px-3 py-2 rounded-md border text-xs font-medium transition-all">
+        OpenAI API
+      </button>
     </div>
 
     <div x-show="settings.chatModel === 'ollama'"
@@ -172,6 +179,39 @@
         </button>
         <span x-show="ollamaTestResult" x-text="ollamaTestResult"
               :class="ollamaTestOk ? 'text-accent' : 'text-error'"
+              class="text-xs font-mono"></span>
+      </div>
+    </div>
+
+    <div x-show="settings.chatModel === 'openai'"
+         class="bg-app border border-app rounded-md p-4 space-y-3 mb-4">
+      <p class="text-muted text-xs leading-relaxed">
+        Any OpenAI-compatible endpoint (LiteLLM, llama-swap, vLLM, …). The model
+        must support tool/function calling. Leave fields blank to use the server's
+        environment defaults.
+      </p>
+      <div>
+        <label class="text-muted text-xs uppercase tracking-wider block mb-1.5">Base URL</label>
+        <input x-model="settings.openaiBaseUrl" placeholder="http://localhost:4000/v1"
+               class="w-full bg-surface border border-app rounded-md px-3 py-2 text-sm text-primary focus:outline-none transition-colors">
+      </div>
+      <div>
+        <label class="text-muted text-xs uppercase tracking-wider block mb-1.5">Model name</label>
+        <input x-model="settings.openaiModel" placeholder="gpt-4o-mini"
+               class="w-full bg-surface border border-app rounded-md px-3 py-2 text-sm text-primary focus:outline-none transition-colors">
+      </div>
+      <div>
+        <label class="text-muted text-xs uppercase tracking-wider block mb-1.5">API key (optional)</label>
+        <input x-model="settings.openaiApiKey" type="password" placeholder="sk-..."
+               class="w-full bg-surface border border-app rounded-md px-3 py-2 text-sm text-primary focus:outline-none transition-colors">
+      </div>
+      <div class="flex items-center gap-3">
+        <button @click="testOpenai()"
+                class="px-3 py-1.5 rounded-md border border-app text-secondary hover:text-primary text-xs transition-all">
+          Test connection
+        </button>
+        <span x-show="openaiTestResult" x-text="openaiTestResult"
+              :class="openaiTestOk ? 'text-accent' : 'text-error'"
               class="text-xs font-mono"></span>
       </div>
     </div>
@@ -271,6 +311,7 @@
             class="text-xs px-3 py-1 rounded-full border border-app text-secondary bg-transparent hover:text-primary transition-colors cursor-pointer">
       <span x-show="aiBackend === 'claude'">Claude Sonnet 4.5</span>
       <span x-show="aiBackend === 'ollama'">Ollama <span x-text="settings.ollamaModel"></span></span>
+      <span x-show="aiBackend === 'openai'">OpenAI <span x-text="settings.openaiModel || 'model'"></span></span>
       <span x-show="aiBackend === 'none'">Not configured</span>
     </button>
   </div>
@@ -479,6 +520,8 @@ document.addEventListener('alpine:init', () => {
     setupOk: false,
     ollamaTestResult: '',
     ollamaTestOk: false,
+    openaiTestResult: '',
+    openaiTestOk: false,
     tools: [],
     showKeys: {},
     setupData: {},
@@ -488,6 +531,9 @@ document.addEventListener('alpine:init', () => {
       chatModel: 'claude',
       ollamaModel: 'llama3.2',
       ollamaHost: 'http://localhost:11434',
+      openaiBaseUrl: '',
+      openaiModel: '',
+      openaiApiKey: '',
     },
 
     suggestions: [
@@ -570,6 +616,7 @@ document.addEventListener('alpine:init', () => {
         this.aiBackend = d.ai_backend || 'none';
         if (d.ollama_host) this.settings.ollamaHost = d.ollama_host;
         if (this.aiBackend === 'ollama') this.settings.chatModel = 'ollama';
+        else if (this.aiBackend === 'openai') this.settings.chatModel = 'openai';
         else if (this.aiBackend === 'claude') this.settings.chatModel = 'claude';
         this.fetchTools();
       } catch {}
@@ -601,7 +648,7 @@ document.addEventListener('alpine:init', () => {
       } catch {}
 
       if (this.aiBackend === 'none') {
-        this._pushError('No AI backend configured. Add your ANTHROPIC_API_KEY in Settings, or start Ollama and select it as the backend.');
+        this._pushError('No AI backend configured. Add your ANTHROPIC_API_KEY in Settings, configure an OpenAI-compatible endpoint (OPENAI_BASE_URL), or start Ollama and select it as the backend.');
         return;
       }
 
@@ -629,6 +676,9 @@ document.addEventListener('alpine:init', () => {
         model: this.settings.chatModel,
         ollama_model: this.settings.ollamaModel,
         ollama_host: this.settings.ollamaHost,
+        openai_base_url: this.settings.openaiBaseUrl,
+        openai_model: this.settings.openaiModel,
+        openai_api_key: this.settings.openaiApiKey,
       };
 
       let fullText = '';
@@ -836,6 +886,31 @@ document.addEventListener('alpine:init', () => {
         else        { this.ollamaTestResult = `HTTP ${r.status}`; }
       } catch (e) {
         this.ollamaTestResult = e.message;
+      }
+    },
+
+    async testOpenai() {
+      this.openaiTestResult = 'Testing...';
+      this.openaiTestOk = false;
+      const base = (this.settings.openaiBaseUrl || '').replace(/\/$/, '');
+      if (!base) {
+        // No URL entered — fall back to the server-side check of the configured endpoint.
+        try {
+          const r = await fetch('/api/chat/test', { signal: AbortSignal.timeout(4000) });
+          const d = await r.json();
+          if (d.backend === 'openai') { this.openaiTestOk = true; this.openaiTestResult = 'Connected (server default)'; }
+          else { this.openaiTestResult = 'No endpoint configured'; }
+        } catch (e) { this.openaiTestResult = e.message; }
+        return;
+      }
+      try {
+        const headers = {};
+        if (this.settings.openaiApiKey) headers['Authorization'] = 'Bearer ' + this.settings.openaiApiKey;
+        const r = await fetch(base + '/models', { headers, signal: AbortSignal.timeout(4000) });
+        if (r.ok) { this.openaiTestOk = true; this.openaiTestResult = 'Connected'; }
+        else      { this.openaiTestResult = `HTTP ${r.status}`; }
+      } catch (e) {
+        this.openaiTestResult = e.message;
       }
     },
   }));

--- a/openosint/web_server.py
+++ b/openosint/web_server.py
@@ -282,6 +282,10 @@ def _get_ai_backend() -> tuple[str, str | None, bool | None]:
     """Return (backend_name, ollama_host, ollama_reachable)."""
     if os.environ.get("ANTHROPIC_API_KEY", "").strip():
         return "claude", None, None
+    # An OpenAI-compatible endpoint (LiteLLM, llama-swap, vLLM, …) takes
+    # precedence over Ollama when configured.
+    if os.environ.get("OPENAI_BASE_URL", "").strip():
+        return "openai", None, None
     ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
     try:
         resp = _requests.get(f"{ollama_host}/api/tags", timeout=2)
@@ -302,6 +306,32 @@ class ChatRequest(BaseModel):
     model: str = "claude"
     ollama_model: str = "llama3.2"
     ollama_host: str = "http://localhost:11434"
+    openai_base_url: str = ""
+    openai_model: str = ""
+    openai_api_key: str = ""
+
+
+def _select_chat_backend(req: "ChatRequest") -> str:
+    """Resolve which AI backend to use for a chat request: openai | ollama | claude."""
+    has_anthropic = bool(os.environ.get("ANTHROPIC_API_KEY", "").strip())
+    openai_base = (req.openai_base_url or os.environ.get("OPENAI_BASE_URL", "")).strip()
+
+    # Explicit selection from the UI takes priority.
+    if req.model == "openai":
+        return "openai"
+    if req.model == "ollama":
+        return "ollama"
+    if req.model == "claude" and has_anthropic:
+        return "claude"
+
+    # Auto-detect when no explicit, usable selection was made.
+    if has_anthropic:
+        return "claude"
+    if openai_base:
+        return "openai"
+    if req.ollama_host:
+        return "ollama"
+    return "claude"
 
 
 # ---------------------------------------------------------------------------
@@ -551,6 +581,124 @@ async def _stream_ollama(
 
             yield {"type": "tool_result", "tool": tool_name, "output": result, "elapsed": elapsed}
             tool_results_for_next.append({"role": "tool", "content": result})
+
+        msgs = (
+            msgs
+            + [{"role": "assistant", "content": content, "tool_calls": tool_calls}]
+            + tool_results_for_next
+        )
+
+    yield {"type": "done"}
+
+
+async def _stream_openai(
+    messages: list[dict],
+    base_url: str,
+    api_key: str,
+    model: str,
+) -> AsyncIterator[dict]:
+    """Yield SSE event dicts using any OpenAI-compatible chat-completions API."""
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/completions"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    msgs = list(messages)
+
+    openai_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": t["name"],
+                "description": t["description"],
+                "parameters": t["input_schema"],
+            },
+        }
+        for t in _CLAUDE_TOOLS
+    ]
+
+    while True:
+        payload = {
+            "model": model,
+            "messages": msgs,
+            "tools": openai_tools,
+            "tool_choice": "auto",
+            "stream": False,
+        }
+        try:
+            if _httpx is not None:
+                async with _httpx.AsyncClient(timeout=180) as client:
+                    r = await client.post(url, json=payload, headers=headers)
+                if r.status_code != 200:
+                    yield {
+                        "type": "error",
+                        "message": f"OpenAI endpoint returned HTTP {r.status_code}: {r.text[:300]}",
+                    }
+                    return
+                data = r.json()
+            else:
+                _payload = payload  # capture for lambda
+                raw = await asyncio.to_thread(
+                    lambda: _requests.post(url, json=_payload, headers=headers, timeout=180)
+                )
+                if raw.status_code != 200:
+                    yield {
+                        "type": "error",
+                        "message": f"OpenAI endpoint returned HTTP {raw.status_code}: {raw.text[:300]}",
+                    }
+                    return
+                data = raw.json()
+        except Exception as exc:
+            yield {"type": "error", "message": f"OpenAI request failed: {exc}"}
+            return
+
+        choices = data.get("choices") or []
+        if not choices:
+            yield {
+                "type": "error",
+                "message": f"OpenAI endpoint returned no choices: {str(data)[:300]}",
+            }
+            return
+        msg = choices[0].get("message", {})
+        content = msg.get("content") or ""
+        tool_calls = msg.get("tool_calls") or []
+
+        if content:
+            yield {"type": "text", "content": content}
+
+        if not tool_calls:
+            break
+
+        tool_results_for_next = []
+        for tc in tool_calls:
+            fn = tc.get("function", {})
+            tool_name = fn.get("name", "")
+            raw_args = fn.get("arguments", {})
+            if isinstance(raw_args, str):
+                try:
+                    raw_args = json.loads(raw_args)
+                except Exception:
+                    raw_args = {"input": raw_args}
+            tool_input = raw_args.get("input", "")
+            if not tool_input and raw_args:
+                tool_input = next(
+                    (v for v in raw_args.values() if isinstance(v, str)), str(raw_args)
+                )
+
+            yield {"type": "tool_start", "tool": tool_name, "input": str(tool_input)}
+
+            t0 = time.monotonic()
+            result = await _run_tool(tool_name, str(tool_input))
+            elapsed = round(time.monotonic() - t0, 2)
+
+            yield {"type": "tool_result", "tool": tool_name, "output": result, "elapsed": elapsed}
+            tool_results_for_next.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.get("id", ""),
+                    "content": result,
+                }
+            )
 
         msgs = (
             msgs
@@ -826,6 +974,30 @@ def create_app() -> FastAPI:
         if has_claude:
             return {"status": "ok", "backend": "claude", "ollama_reachable": None}
 
+        # OpenAI-compatible endpoint (LiteLLM, llama-swap, vLLM, …).
+        openai_base = os.environ.get("OPENAI_BASE_URL", "").strip().rstrip("/")
+        if openai_base:
+            api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+            headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+            try:
+                if _httpx is not None:
+                    async with _httpx.AsyncClient(timeout=2.5) as client:
+                        r = await client.get(f"{openai_base}/models", headers=headers)
+                        reachable = r.status_code == 200
+                else:
+                    raw = await asyncio.to_thread(
+                        lambda: _requests.get(f"{openai_base}/models", headers=headers, timeout=2.5)
+                    )
+                    reachable = raw.status_code == 200
+            except Exception:
+                reachable = False
+            return {
+                "status": "ok",
+                "backend": "openai" if reachable else "none",
+                "openai_reachable": reachable,
+                "openai_base_url": openai_base,
+            }
+
         ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
         try:
             if _httpx is not None:
@@ -860,11 +1032,18 @@ def create_app() -> FastAPI:
                 messages.append({"role": role, "content": content})
         messages.append({"role": "user", "content": req.message})
 
-        use_ollama = req.model == "ollama" or not os.environ.get("ANTHROPIC_API_KEY", "").strip()
-        use_ollama = use_ollama and bool(req.ollama_host)
+        backend = _select_chat_backend(req)
 
         async def generate():
-            if use_ollama:
+            if backend == "openai":
+                base_url = (
+                    req.openai_base_url
+                    or os.environ.get("OPENAI_BASE_URL", "http://localhost:8080/v1")
+                ).strip()
+                api_key = (req.openai_api_key or os.environ.get("OPENAI_API_KEY", "")).strip()
+                model = (req.openai_model or os.environ.get("OPENAI_MODEL", "gpt-4o-mini")).strip()
+                gen = _stream_openai(messages, base_url, api_key, model)
+            elif backend == "ollama":
                 gen = _stream_ollama(messages, req.ollama_host, req.ollama_model)
             else:
                 gen = _stream_claude(messages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ shodan = [
 ollama = [
     "ollama>=0.3.0",
 ]
+openai = [
+    "openai>=1.40.0",
+]
 pdf = [
     "reportlab>=4.0.0",
 ]
@@ -82,6 +85,7 @@ web = [
 all = [
     "shodan>=1.31.0",
     "ollama>=0.3.0",
+    "openai>=1.40.0",
     "reportlab>=4.0.0",
     "censys>=2.2.0",
     "fastapi>=0.110.0",


### PR DESCRIPTION
## Summary
Adds an OpenAI-compatible AI backend (`--provider openai`) alongside the existing Anthropic and Ollama providers, so OpenOSINT can drive any endpoint that speaks the OpenAI `/v1/chat/completions` protocol (LiteLLM, llama-swap, vLLM, LM Studio, …). The target model must support tool/function calling.

## Type of change
- [x] New feature

## Test plan
- `pytest` → 140 passed, 2 skipped
- `ruff check` + `ruff format --check` clean
- Verified end-to-end against a local OpenAI-compatible gateway: REPL agent loop (`OpenAICompatibleAgent`), Web UI `_stream_openai` SSE path, `/api/health` + `/api/chat/test` backend detection, and a real tool-using investigation (WHOIS) returning correct results.

## Checklist
- [x] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, `CLAUDE.md`
- [x] README and docs updated where applicable
- [x] `.env.example` updated for any new environment variable
- [x] No secrets or API keys committed