### PR TITLE
feat: add Hudson Rock infostealer-corpus integration (v2.20.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,9 @@ CENSYS_SECRET=your_secret
 # Optional — AbuseIPDB IP reputation
 ABUSEIPDB_API_KEY=your_key
 
+# Optional — Hudson Rock infostealer intelligence. Free public API works without a key;
+# set HUDSONROCK_API_KEY to send it as Bearer auth (e.g. for commercial-tier access).
+HUDSONROCK_API_KEY=your_key
+
 # Optional — GitHub profile/repo/email discovery (raises rate limit 60 → 5000 req/h)
 GITHUB_TOKEN=your_token

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.OpenOSINT/openosint",
   "title": "OpenOSINT",
-  "description": "AI-powered OSINT agent & MCP server. 16 tools: email, breach, IP, WHOIS, DNS, Shodan, GitHub & more.",
-  "version": "2.19.0",
+  "description": "AI-powered OSINT agent & MCP server. 17 tools: email, breach, IP, WHOIS, DNS, Shodan, GitHub, Hudson Rock & more.",
+  "version": "2.20.0",
   "websiteUrl": "https://openosint.tech",
   "repository": {
     "url": "https://github.com/OpenOSINT/OpenOSINT",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "openosint",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "transport": {
         "type": "stdio"
       },
@@ -50,6 +50,13 @@
         {
           "name": "ABUSEIPDB_API_KEY",
           "description": "AbuseIPDB API key for IP abuse reputation checks (search_abuseipdb tool)",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "HUDSONROCK_API_KEY",
+          "description": "Hudson Rock Cavalier API key for infostealer-corpus checks (search_hudsonrock tool). Free public endpoint works without a key; this variable is sent as Bearer auth when set (commercial-tier access).",
           "isRequired": false,
           "isSecret": true,
           "format": "string"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ OpenOSINT adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.20.0] — 2026-06-06
+
+### Added
+- **Hudson Rock infostealer intelligence** (`openosint/tools/search_hudsonrock.py`):
+  new tool `search_hudsonrock` querying Hudson Rock's Cavalier API for credentials
+  exposed via infostealer malware corpora (RedLine, Lumma, Raccoon, Vidar, StealC,
+  …). Auto-routes by input shape: emails to `/search-by-email`, domains to
+  `/search-by-domain`, usernames and phone numbers (E.164) to `/search-by-username`.
+  No API key required — free public endpoint with a 50 req/10s rate limit.
+  Available as CLI subcommand `openosint hudsonrock QUERY [-t SECONDS]`, in the AI
+  agent tool loop, the MCP server, the REPL, and the Web UI. Closes
+  [#4](https://github.com/OpenOSINT/OpenOSINT/issues/4).
+
+### Changed
+- Version bumped to 2.20.0; tool count: 16 → 17.
+- Agent `SYSTEM_PROMPT` updated: infostealer-compromise checks now suggest
+  `search_hudsonrock` alongside `search_breach`.
+- MCP server docstring updated to reflect 17 tools.
+- `web_server.py` `_VERSION` bumped from 2.18.1 → 2.20.0 (was stale).
+- README tools table, feature line, and tool count updated.
+
+---
+
 ## [2.19.0] — 2026-06-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ OpenOSINT adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [2.20.0] — 2026-06-06
+## [2.20.0] — 2026-06-05
 
 ### Added
 - **Hudson Rock infostealer intelligence** (`openosint/tools/search_hudsonrock.py`):

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ mcp-name: io.github.OpenOSINT/openosint
   <img src="docs/logo.svg" alt="OpenOSINT" width="200" />
   <h1>OpenOSINT</h1>
   <p><strong>AI-powered OSINT agent. Interactive REPL · CLI · MCP Server · Web UI</strong></p>
-  <p>16 tools. Powered by Anthropic Claude or local Ollama. For authorized security research only.</p>
+  <p>17 tools. Powered by Anthropic Claude or local Ollama. For authorized security research only.</p>
 </div>
 
 <div align="center">
@@ -37,8 +37,8 @@ OpenOSINT is an AI agent for Open Source Intelligence with three interfaces: an 
 
 ## Features
 
-- **AI tool chaining** — the agent decides which of 16 tools to run, chains them based on findings, and compiles a structured report
-- **16 modular tools** covering email, username, breach, WHOIS, IP, subdomain, dorks, paste, phone, Shodan, VirusTotal, Censys, IP2Location, AbuseIPDB, GitHub, and DNS
+- **AI tool chaining** — the agent decides which of 17 tools to run, chains them based on findings, and compiles a structured report
+- **17 modular tools** covering email, username, breach, WHOIS, IP, subdomain, dorks, paste, phone, Shodan, VirusTotal, Censys, IP2Location, AbuseIPDB, GitHub, DNS, and Hudson Rock infostealer corpus
 - **Anthropic, Ollama, or any OpenAI-compatible endpoint** — use Claude via API key, run fully offline with a local Ollama model, or point at any OpenAI-compatible server (LiteLLM, llama-swap, vLLM, LM Studio, …)
 - **MCP server** — expose all tools natively to Claude Code and Claude Desktop
 - **Parallel execution** — `--parallel` runs complementary tools concurrently via `asyncio.gather()`
@@ -102,6 +102,7 @@ Store all keys in a `.env` file at the project root (copy `.env.example`). `pyth
 | `CENSYS_API_ID` + `CENSYS_SECRET` | `search_censys` | Optional | Censys Search API — [get one](https://censys.io/account) |
 | `ABUSEIPDB_API_KEY` | `search_abuseipdb` | Optional | AbuseIPDB v2 — [get one](https://www.abuseipdb.com/account/api) |
 | `GITHUB_TOKEN` | `search_github` | Optional | GitHub API — raises rate limit from 60 to 5000 req/h — [get one](https://github.com/settings/tokens) |
+| `HUDSONROCK_API_KEY` | `search_hudsonrock` | Optional | Hudson Rock Cavalier API — free public endpoint works without a key; this var is sent as Bearer auth when set (commercial-tier access) — [Hudson Rock](https://www.hudsonrock.com/) |
 
 **Optional Python packages:**
 
@@ -133,6 +134,7 @@ Store all keys in a `.env` file at the project root (copy `.env.example`). `pyth
 | `search_abuseipdb` | AbuseIPDB v2 API | IP abuse reputation: confidence score, reports, country, ISP |
 | `search_github` | GitHub REST API | Profile, repos, commit-discovered emails, username/keyword search |
 | `search_dns` | dnspython (built-in) | A/AAAA/MX/NS/TXT/CNAME/SOA records; SPF, DMARC, DKIM analysis |
+| `search_hudsonrock` | Hudson Rock Cavalier API | Infostealer-compromised credentials per email, domain, username, or phone — no key required |
 
 ### search_email
 
@@ -605,7 +607,7 @@ For commercial use in closed-source products, a separate license is required. �
 
 *For authorized security research only. See [DISCLAIMER.md](DISCLAIMER.md).*
 
-*OpenOSINT v2.19.0 — June 5, 2026*
+*OpenOSINT v2.20.0 — June 5, 2026*
 
 ## Star History
 

--- a/openosint/__init__.py
+++ b/openosint/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.19.0"
+__version__ = "2.20.0"
 version = __version__

--- a/openosint/agent.py
+++ b/openosint/agent.py
@@ -32,6 +32,7 @@ from openosint.tools.search_dns import run_dns_osint
 from openosint.tools.search_domain import run_domain_osint
 from openosint.tools.search_email import run_email_osint
 from openosint.tools.search_github import run_github_osint
+from openosint.tools.search_hudsonrock import run_hudsonrock_osint
 from openosint.tools.search_ip import run_ip_osint
 from openosint.tools.search_ip2location import run_ip2location_osint
 from openosint.tools.search_paste import run_paste_osint
@@ -306,6 +307,30 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "required": ["domain"],
         },
     },
+    {
+        "name": "search_hudsonrock",
+        "description": (
+            "Query Hudson Rock's Cavalier infostealer corpus for credentials and assets "
+            "exposed via malware (RedLine, Lumma, Raccoon, Vidar, StealC, …). "
+            "Auto-routes by input shape: emails → per-record stealer history; domains → "
+            "aggregate employee/user/third-party compromise stats; usernames and phone "
+            "numbers (E.164) → per-record stealer history. "
+            "Pairs naturally with search_breach for a fuller credential-exposure picture. "
+            "No API key required — free public endpoint."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Target email address, domain, username, or phone number in E.164 format."
+                    ),
+                }
+            },
+            "required": ["query"],
+        },
+    },
 ]
 
 # ---------------------------------------------------------------------------
@@ -329,6 +354,7 @@ _TOOL_MAP: dict[str, Any] = {
     "search_abuseipdb": lambda a: run_abuseipdb_osint(a["ip"], timeout_seconds=30),
     "search_github": lambda a: run_github_osint(a["query"], timeout_seconds=30),
     "search_dns": lambda a: run_dns_osint(a["domain"], timeout_seconds=10),
+    "search_hudsonrock": lambda a: run_hudsonrock_osint(a["query"], timeout_seconds=30),
 }
 
 SYSTEM_PROMPT = """You are OpenOSINT, an expert OSINT analyst assistant running in a terminal.
@@ -341,6 +367,7 @@ INVESTIGATION STRATEGY:
 - For an IP: run search_ip and optionally search_shodan or search_censys for open ports/services.
 - For a GitHub username or handle: use search_github to retrieve profile data, repos, and commit-discovered emails.
 - For IP reputation/abuse: use search_abuseipdb to get the abuseConfidenceScore — a score above 50% indicates a high-risk IP; combine with search_ip or search_shodan for full context.
+- For infostealer-compromise checks (credentials exposed via malware logs like RedLine/Lumma/Raccoon): use search_hudsonrock on the target email, domain, username, or E.164 phone. Pairs naturally with search_breach.
 - For a domain or IP infrastructure: use search_censys for certificate history and port data.
 - For a Shodan query or banners: use search_shodan.
 - Chain tools intelligently: use findings from each step to decide the next.

--- a/openosint/cli.py
+++ b/openosint/cli.py
@@ -38,6 +38,7 @@ from openosint.tools.search_censys import run_censys_osint  # noqa: E402
 from openosint.tools.search_dns import run_dns_osint  # noqa: E402
 from openosint.tools.search_email import run_email_osint  # noqa: E402
 from openosint.tools.search_github import run_github_osint  # noqa: E402
+from openosint.tools.search_hudsonrock import run_hudsonrock_osint  # noqa: E402
 from openosint.tools.search_ip2location import run_ip2location_osint  # noqa: E402
 from openosint.tools.search_paste import run_paste_osint  # noqa: E402
 from openosint.tools.search_shodan import run_shodan_osint  # noqa: E402
@@ -103,6 +104,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "  openosint multi a@x.com,b@y.com             # multi-target inline\n"
             "  openosint --parallel email target@example.com\n"
             "  openosint --json email target@example.com\n"
+            "  openosint hudsonrock tesla.com              # infostealer corpus check\n"
             "  openosint --provider ollama                 # use local Ollama\n"
             "  openosint --provider ollama --ollama-model mistral\n"
         ),
@@ -331,6 +333,26 @@ def _build_parser() -> argparse.ArgumentParser:
         default=10,
         metavar="SECONDS",
         help="DNS query timeout (default: 10).",
+    )
+
+    # hudsonrock
+    hudsonrock_cmd = subparsers.add_parser(
+        "hudsonrock",
+        help="Hudson Rock infostealer-corpus check (no AI). No API key required.",
+    )
+    hudsonrock_cmd.add_argument(
+        "query",
+        type=str,
+        metavar="QUERY",
+        help="Email, domain, username, or phone number (E.164).",
+    )
+    hudsonrock_cmd.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        default=30,
+        metavar="SECONDS",
+        help="Request timeout (default: 30).",
     )
 
     # abuseipdb
@@ -612,6 +634,19 @@ async def _handle_dns(
         _print_result(result)
 
 
+async def _handle_hudsonrock(
+    query: str,
+    timeout: int,
+    json_output: bool = False,
+) -> None:
+    print(f"[*] Hudson Rock lookup: {query}", file=sys.stderr)
+    result = await run_hudsonrock_osint(query=query, timeout_seconds=timeout)
+    if json_output:
+        _emit_json(format_tool_result("search_hudsonrock", query, result))
+    else:
+        _print_result(result)
+
+
 async def _handle_ip2location(
     ip: str,
     timeout: int,
@@ -797,6 +832,8 @@ async def _async_main() -> None:
         await _handle_github(args.query, args.timeout, json_output=json_output)
     elif args.command == "dns":
         await _handle_dns(args.domain, args.timeout, json_output=json_output)
+    elif args.command == "hudsonrock":
+        await _handle_hudsonrock(args.query, args.timeout, json_output=json_output)
     elif args.command == "abuseipdb":
         await _handle_abuseipdb(args.ip, args.timeout, json_output=json_output)
     elif args.command == "ip2location":

--- a/openosint/mcp_server.py
+++ b/openosint/mcp_server.py
@@ -1,13 +1,13 @@
 # openosint/mcp_server.py
 """
-OpenOSINT MCP Server — v2.18.1
+OpenOSINT MCP Server.
 
-Exposes all 16 OSINT tool capabilities plus multi-target investigation
+Exposes all 17 OSINT tool capabilities plus multi-target investigation
 to MCP-compliant AI clients over standard I/O. Tools include:
 search_email, search_username, search_breach, search_whois, search_ip,
 search_domain, generate_dorks, search_paste, search_phone, search_shodan,
 search_virustotal, search_censys, search_ip2location, search_abuseipdb,
-search_github, search_dns.
+search_github, search_dns, search_hudsonrock.
 """
 
 from __future__ import annotations
@@ -29,6 +29,7 @@ from openosint.tools.search_dns import run_dns_osint
 from openosint.tools.search_domain import run_domain_osint
 from openosint.tools.search_email import run_email_osint
 from openosint.tools.search_github import run_github_osint
+from openosint.tools.search_hudsonrock import run_hudsonrock_osint
 from openosint.tools.search_ip import run_ip_osint
 from openosint.tools.search_ip2location import run_ip2location_osint
 from openosint.tools.search_paste import run_paste_osint
@@ -256,6 +257,24 @@ async def list_tools() -> list[Tool]:
             ),
         ),
         Tool(
+            name="search_hudsonrock",
+            description=(
+                "Query Hudson Rock's Cavalier infostealer corpus for credentials and assets "
+                "exposed via malware (RedLine, Lumma, Raccoon, Vidar, StealC, …). "
+                "Auto-routes by input shape: email → per-record stealer history; "
+                "domain → aggregate compromise stats; "
+                "username or phone (E.164) → per-record stealer history. "
+                "No API key required — free public endpoint."
+            ),
+            inputSchema=_with_json(
+                {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                }
+            ),
+        ),
+        Tool(
             name="investigate_multi",
             description=(
                 "Investigate multiple targets in parallel using the full OSINT tool chain. "
@@ -336,6 +355,10 @@ _HANDLERS: dict[str, tuple] = {
     "search_dns": (
         lambda a: run_dns_osint(a["domain"], timeout_seconds=10),
         lambda a: a["domain"],
+    ),
+    "search_hudsonrock": (
+        lambda a: run_hudsonrock_osint(a["query"], timeout_seconds=30),
+        lambda a: a["query"],
     ),
 }
 

--- a/openosint/repl.py
+++ b/openosint/repl.py
@@ -58,6 +58,7 @@ _TOOL_INFO_ROWS = [
     ("search_abuseipdb", "AbuseIPDB API", "IP abuse confidence score"),
     ("search_github", "GitHub API", "Profile, repos, commit-email discovery"),
     ("search_dns", "dnspython", "DNS records & email security audit"),
+    ("search_hudsonrock", "Hudson Rock API", "Infostealer-compromised credentials"),
 ]
 
 # ---------------------------------------------------------------------------

--- a/openosint/tools/search_hudsonrock.py
+++ b/openosint/tools/search_hudsonrock.py
@@ -1,0 +1,225 @@
+# openosint/tools/search_hudsonrock.py
+"""
+Hudson Rock infostealer-corpus intelligence (community tier).
+
+Queries Hudson Rock's Cavalier API for credentials exposed via infostealer
+malware (RedLine, Raccoon, Vidar, Lumma, StealC, …). Free public endpoint,
+no API key, 50 req / 10 s rate limit.
+
+Auto-routes by input shape:
+  - email   (contains '@.')           → /search-by-email
+  - domain  (dotted, alpha TLD)        → /search-by-domain
+  - phone / username (everything else) → /search-by-username
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from typing import Literal
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://cavalier.hudsonrock.com/api/json/v2/osint-tools"
+_DEFAULT_TIMEOUT = 30
+
+_ENDPOINTS = {
+    "email": "/search-by-email",
+    "domain": "/search-by-domain",
+    "username": "/search-by-username",
+}
+_PARAM_KEYS = {"email": "email", "domain": "domain", "username": "username"}
+
+_EMAIL_RE = re.compile(r"^[\w.+-]+@[\w.-]+\.[a-z]{2,}$", re.IGNORECASE)
+_PHONE_BODY_RE = re.compile(r"^[\d\- ]+$")
+_DOMAIN_TLD_RE = re.compile(r"^[a-z]{2,}$", re.IGNORECASE)
+
+Kind = Literal["email", "domain", "username"]
+
+
+def _classify(query: str) -> Kind:
+    q = query.strip()
+    if "@" in q:
+        return "email"
+    if q.startswith("+") and _PHONE_BODY_RE.match(q[1:] or ""):
+        return "username"
+    if "." in q and " " not in q:
+        last = q.rsplit(".", 1)[1]
+        if _DOMAIN_TLD_RE.match(last):
+            return "domain"
+    return "username"
+
+
+def _is_valid_email(value: str) -> bool:
+    return bool(_EMAIL_RE.match(value.strip()))
+
+
+def _raise_for_status(status: int) -> None:
+    if status == 429:
+        raise ValueError("Hudson Rock: rate limit exceeded (50 req / 10s).")
+    if status != 200:
+        raise ValueError(f"Hudson Rock returned HTTP {status}.")
+
+
+async def _fetch_hudsonrock(
+    endpoint: str,
+    param_key: str,
+    value: str,
+    timeout: int,
+    api_key: str = "",
+) -> dict:
+    url = f"{_BASE_URL}{endpoint}"
+    params = {param_key: value}
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    timeout_cfg = aiohttp.ClientTimeout(total=timeout)
+    async with aiohttp.ClientSession(timeout=timeout_cfg) as session:
+        async with session.get(url, params=params, headers=headers) as resp:
+            if resp.status == 404:
+                return {}
+            _raise_for_status(resp.status)
+            return await resp.json()
+
+
+def _format_domain(query: str, data: dict) -> str:
+    total_stealers = data.get("totalStealers", 0) or 0
+    employees = data.get("employees", 0) or 0
+    users = data.get("users", 0) or 0
+    third_parties = data.get("third_parties", 0) or 0
+
+    if not (total_stealers or employees or users):
+        return f"[HudsonRock] No infostealer-compromised credentials found for {query}."
+
+    lines = [
+        "[HudsonRock] Query type: domain",
+        f"[HudsonRock] Target: {query}",
+        f"[HudsonRock] Total stealers seen: {total_stealers:,}",
+        f"[HudsonRock] Compromised employees: {employees:,}",
+        f"[HudsonRock] Compromised users: {users:,}",
+        f"[HudsonRock] Third-party exposures: {third_parties:,}",
+    ]
+    if data.get("last_employee_compromised"):
+        lines.append(f"[HudsonRock] Last employee compromised: {data['last_employee_compromised']}")
+    if data.get("last_user_compromised"):
+        lines.append(f"[HudsonRock] Last user compromised: {data['last_user_compromised']}")
+
+    families = data.get("stealerFamilies") or {}
+    if isinstance(families, dict) and families:
+        named = [
+            (k, v) for k, v in families.items() if k != "total" and isinstance(v, (int, float))
+        ]
+        top = sorted(named, key=lambda kv: kv[1], reverse=True)[:5]
+        if top:
+            lines.append(
+                "[HudsonRock] Top stealer families: "
+                + ", ".join(f"{name} ({count:,})" for name, count in top)
+            )
+
+    antiviruses = ((data.get("antiviruses") or {}).get("list")) or []
+    if isinstance(antiviruses, list) and antiviruses:
+        top_av = sorted(
+            (a for a in antiviruses if isinstance(a, dict)),
+            key=lambda a: a.get("count", 0),
+            reverse=True,
+        )[:3]
+        if top_av:
+            lines.append(
+                "[HudsonRock] Top AVs on victims: "
+                + ", ".join(f"{a.get('name', '?')} ({a.get('count', 0)})" for a in top_av)
+            )
+
+    lines.append("⚠️  COMPROMISED — credentials present in infostealer corpus")
+    return "\n".join(lines)
+
+
+def _format_stealers(kind: Kind, query: str, data: dict) -> str:
+    stealers = data.get("stealers") or []
+    if not isinstance(stealers, list) or not stealers:
+        return f"[HudsonRock] No infostealer-compromised credentials found for {query}."
+
+    corp = data.get("total_corporate_services", 0) or 0
+    user = data.get("total_user_services", 0) or 0
+
+    lines = [
+        f"[HudsonRock] Query type: {kind}",
+        f"[HudsonRock] Target: {query}",
+        f"[HudsonRock] Stealer records: {len(stealers)}",
+        f"[HudsonRock] Corporate services exposed: {corp}",
+        f"[HudsonRock] User services exposed: {user}",
+    ]
+
+    for i, s in enumerate(stealers[:3], 1):
+        if not isinstance(s, dict):
+            continue
+        lines.append(f"[HudsonRock] --- Record {i} ---")
+        if s.get("date_compromised"):
+            lines.append(f"[HudsonRock]   Date compromised: {s['date_compromised']}")
+        if s.get("computer_name"):
+            lines.append(f"[HudsonRock]   Computer name: {s['computer_name']}")
+        if s.get("operating_system"):
+            lines.append(f"[HudsonRock]   OS: {s['operating_system']}")
+        if s.get("ip"):
+            lines.append(f"[HudsonRock]   IP (masked): {s['ip']}")
+        avs = s.get("antiviruses")
+        if isinstance(avs, list) and avs:
+            lines.append(f"[HudsonRock]   AVs on machine: {', '.join(str(a) for a in avs)}")
+        logins = s.get("top_logins")
+        if isinstance(logins, list) and logins:
+            lines.append(
+                f"[HudsonRock]   Top logins (redacted): {', '.join(str(x) for x in logins[:3])}"
+            )
+
+    if len(stealers) > 3:
+        lines.append(f"[HudsonRock] ... {len(stealers) - 3} more record(s) omitted")
+
+    lines.append("⚠️  COMPROMISED — credentials present in infostealer corpus")
+    return "\n".join(lines)
+
+
+def _format_results(kind: Kind, query: str, data: dict) -> str:
+    if kind == "domain":
+        return _format_domain(query, data)
+    return _format_stealers(kind, query, data)
+
+
+async def run_hudsonrock_osint(
+    query: str,
+    timeout_seconds: int = _DEFAULT_TIMEOUT,
+) -> str:
+    """Search Hudson Rock's Cavalier infostealer corpus.
+
+    The free public endpoint requires no API key. ``HUDSONROCK_API_KEY``, if set,
+    is sent as ``Authorization: Bearer <key>`` for commercial-tier access.
+    """
+    q = query.strip()
+    if not q:
+        return "Invalid query: empty input."
+
+    kind = _classify(q)
+
+    if kind == "email" and not _is_valid_email(q):
+        return "Invalid query: malformed email address."
+
+    api_key = os.environ.get("HUDSONROCK_API_KEY", "").strip()
+
+    try:
+        payload = await _fetch_hudsonrock(
+            _ENDPOINTS[kind],
+            _PARAM_KEYS[kind],
+            q,
+            timeout_seconds,
+            api_key=api_key,
+        )
+        return _format_results(kind, q, payload)
+    except asyncio.TimeoutError:
+        return f"Scan error: Hudson Rock request timed out after {timeout_seconds}s."
+    except aiohttp.ClientError as exc:
+        return f"Scan error: Network error querying Hudson Rock: {exc}"
+    except ValueError as exc:
+        return f"Scan error: {exc}"
+    except Exception as exc:
+        logger.exception("Unexpected error during Hudson Rock lookup.")
+        return f"Internal error: {exc}"

--- a/openosint/tools/search_hudsonrock.py
+++ b/openosint/tools/search_hudsonrock.py
@@ -169,7 +169,7 @@ def _format_stealers(kind: Kind, query: str, data: dict) -> str:
         logins = s.get("top_logins")
         if isinstance(logins, list) and logins:
             lines.append(
-                f"[HudsonRock]   Top logins (redacted): {', '.join(str(x) for x in logins[:3])}"
+                f"[HudsonRock]   Top logins (as returned by API): {', '.join(str(x) for x in logins[:3])}"
             )
 
     if len(stealers) > 3:

--- a/openosint/web_server.py
+++ b/openosint/web_server.py
@@ -44,6 +44,7 @@ from openosint.tools.search_breach import run_breach_osint
 from openosint.tools.search_censys import run_censys_osint
 from openosint.tools.search_domain import run_domain_osint
 from openosint.tools.search_email import run_email_osint
+from openosint.tools.search_hudsonrock import run_hudsonrock_osint
 from openosint.tools.search_ip import run_ip_osint
 from openosint.tools.search_ip2location import run_ip2location_osint
 from openosint.tools.search_paste import run_paste_osint
@@ -53,7 +54,7 @@ from openosint.tools.search_username import run_username_osint
 from openosint.tools.search_virustotal import run_virustotal_osint
 from openosint.tools.search_whois import run_whois_osint
 
-_VERSION = "2.18.1"
+_VERSION = "2.20.0"
 _ROOT = Path(__file__).parent.parent
 
 # Web assets: prefer the package-relative path (pip install) with project-root fallback (dev/editable)
@@ -207,6 +208,16 @@ _TOOL_CATALOG: list[dict] = [
         "requires_env": ["VIRUSTOTAL_API_KEY"],
         "env_hints": {"VIRUSTOTAL_API_KEY": "virustotal.com/gui/my-apikey"},
     },
+    {
+        "name": "search_hudsonrock",
+        "description": "Check Hudson Rock's infostealer corpus for compromised credentials.",
+        "input_label": "Email, domain, or username/phone",
+        "input_placeholder": "user@example.com",
+        "category": "Identity",
+        "icon": "🦹",
+        "requires_binary": [],
+        "requires_env": [],
+    },
 ]
 
 # Map tool name → async callable(input_value: str, timeout: int) -> str
@@ -224,6 +235,7 @@ _RUNNERS: dict[str, object] = {
     "search_shodan": lambda v, t: run_shodan_osint(v, timeout_seconds=t),
     "search_virustotal": lambda v, t: run_virustotal_osint(v, timeout_seconds=t),
     "search_censys": lambda v, t: run_censys_osint(v, timeout_seconds=t),
+    "search_hudsonrock": lambda v, t: run_hudsonrock_osint(v, timeout_seconds=t),
 }
 
 # Claude tool schemas (one string "input" param per tool)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openosint"
-version = "2.19.0"
-description = "AI-powered OSINT agent, MCP server, and CLI. Interactive REPL + 16 tools. Anthropic Claude or local Ollama. For authorized security research use only."
+version = "2.20.0"
+description = "AI-powered OSINT agent, MCP server, and CLI. Interactive REPL + 17 tools. Anthropic Claude or local Ollama. For authorized security research use only."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"

--- a/tests/test_hudsonrock.py
+++ b/tests/test_hudsonrock.py
@@ -1,0 +1,326 @@
+# tests/test_hudsonrock.py
+"""Tests for v2.20.0 — Hudson Rock infostealer integration."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+
+from openosint.tools.search_hudsonrock import (
+    _classify,
+    _format_domain,
+    _format_stealers,
+    run_hudsonrock_osint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures grounded in the live API response shapes (probed at impl time)
+# ---------------------------------------------------------------------------
+
+
+def _domain_payload(stealers: int = 1000, employees: int = 50) -> dict:
+    return {
+        "total": 100,
+        "totalStealers": stealers,
+        "employees": employees,
+        "users": 200,
+        "third_parties": 30,
+        "totalUrls": 500,
+        "last_employee_compromised": "2024-11-03T08:59:11.953Z",
+        "last_user_compromised": "2024-12-15T08:59:11.953Z",
+        "stealerFamilies": {
+            "total": stealers,
+            "RedLine": 400,
+            "Lumma": 350,
+            "Raccoon": 150,
+            "Vidar": 100,
+        },
+        "antiviruses": {
+            "total": 312,
+            "list": [
+                {"count": 125, "name": "Windows Defender"},
+                {"count": 60, "name": "Kaspersky"},
+                {"count": 30, "name": "Avast"},
+            ],
+        },
+    }
+
+
+def _empty_domain_payload() -> dict:
+    return {
+        "total": 0,
+        "totalStealers": 0,
+        "employees": 0,
+        "users": 0,
+        "third_parties": 0,
+    }
+
+
+def _stealer_payload(n: int = 2) -> dict:
+    return {
+        "message": "This is a free service from Hudson Rock.",
+        "total_corporate_services": 5,
+        "total_user_services": 200,
+        "stealers": [
+            {
+                "date_compromised": "2023-08-09T08:59:11.953Z",
+                "computer_name": f"Dell_Laptop_{i}",
+                "operating_system": "Windows 10 (10.0.19045)",
+                "malware_path": "C:\\Windows\\jsc.exe",
+                "antiviruses": ["Windows Defender", "Kaspersky"],
+                "ip": "122.161.**.**",
+                "top_passwords": ["[redacted]"] * 5,
+                "top_logins": ["user@example.com", "admin@example.com"],
+            }
+            for i in range(n)
+        ],
+    }
+
+
+def _empty_stealer_payload() -> dict:
+    return {"stealers": [], "total_corporate_services": 0, "total_user_services": 0}
+
+
+# ---------------------------------------------------------------------------
+# _classify — pure routing logic
+# ---------------------------------------------------------------------------
+
+
+def test_classify_email() -> None:
+    assert _classify("user@example.com") == "email"
+
+
+def test_classify_domain() -> None:
+    assert _classify("tesla.com") == "domain"
+
+
+def test_classify_username_plain() -> None:
+    assert _classify("johndoe99") == "username"
+
+
+def test_classify_phone_e164_routes_to_username() -> None:
+    assert _classify("+19777334049") == "username"
+
+
+def test_classify_domain_strips_whitespace() -> None:
+    assert _classify("  example.org  ") == "domain"
+
+
+def test_classify_username_with_dot_in_alpha_tld_falls_to_domain() -> None:
+    # Documented limitation: "user.name" looks like a domain. Acceptable —
+    # SYSTEM_PROMPT instructs the agent to pass clean inputs.
+    assert _classify("user.name") == "domain"
+
+
+# ---------------------------------------------------------------------------
+# _format_domain — output shape
+# ---------------------------------------------------------------------------
+
+
+def test_format_domain_includes_counts_and_warning() -> None:
+    result = _format_domain("tesla.com", _domain_payload())
+    assert "[HudsonRock] Query type: domain" in result
+    assert "Target: tesla.com" in result
+    assert "Total stealers seen: 1,000" in result
+    assert "Compromised employees: 50" in result
+    assert "COMPROMISED" in result
+    assert "⚠️" in result
+
+
+def test_format_domain_top_stealer_families() -> None:
+    result = _format_domain("tesla.com", _domain_payload())
+    assert "Top stealer families" in result
+    assert "RedLine" in result
+
+
+def test_format_domain_top_antiviruses() -> None:
+    result = _format_domain("tesla.com", _domain_payload())
+    assert "Windows Defender" in result
+
+
+def test_format_domain_empty_payload_no_warning() -> None:
+    result = _format_domain("clean.example", _empty_domain_payload())
+    assert "No infostealer-compromised credentials" in result
+    assert "COMPROMISED" not in result
+
+
+# ---------------------------------------------------------------------------
+# _format_stealers — output shape (email / username branch)
+# ---------------------------------------------------------------------------
+
+
+def test_format_stealers_lists_records() -> None:
+    result = _format_stealers("email", "user@x.com", _stealer_payload(n=2))
+    assert "Stealer records: 2" in result
+    assert "Dell_Laptop_0" in result
+    assert "Windows 10" in result
+    assert "COMPROMISED" in result
+
+
+def test_format_stealers_truncates_after_three() -> None:
+    result = _format_stealers("username", "johndoe", _stealer_payload(n=10))
+    assert "Stealer records: 10" in result
+    assert "7 more record(s) omitted" in result
+
+
+def test_format_stealers_empty_returns_no_data_message() -> None:
+    result = _format_stealers("email", "clean@x.com", _empty_stealer_payload())
+    assert "No infostealer-compromised credentials" in result
+    assert "COMPROMISED" not in result
+
+
+# ---------------------------------------------------------------------------
+# run_hudsonrock_osint — routing + happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_email_routes_to_email_endpoint() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        return_value=_stealer_payload(n=1),
+    ) as mock_fetch:
+        result = await run_hudsonrock_osint("user@example.com")
+    assert mock_fetch.await_args.args[0] == "/search-by-email"
+    assert mock_fetch.await_args.args[1] == "email"
+    assert "[HudsonRock]" in result
+
+
+async def test_domain_routes_to_domain_endpoint() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        return_value=_domain_payload(),
+    ) as mock_fetch:
+        result = await run_hudsonrock_osint("tesla.com")
+    assert mock_fetch.await_args.args[0] == "/search-by-domain"
+    assert mock_fetch.await_args.args[1] == "domain"
+    assert "Query type: domain" in result
+
+
+async def test_username_routes_to_username_endpoint() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        return_value=_stealer_payload(n=1),
+    ) as mock_fetch:
+        await run_hudsonrock_osint("johndoe99")
+    assert mock_fetch.await_args.args[0] == "/search-by-username"
+    assert mock_fetch.await_args.args[1] == "username"
+
+
+async def test_phone_e164_routes_to_username_endpoint() -> None:
+    # Maintainer-confirmed: Hudson Rock has no separate phone endpoint;
+    # phone numbers are queried via /search-by-username.
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        return_value=_empty_stealer_payload(),
+    ) as mock_fetch:
+        await run_hudsonrock_osint("+19777334049")
+    assert mock_fetch.await_args.args[0] == "/search-by-username"
+
+
+# ---------------------------------------------------------------------------
+# HUDSONROCK_API_KEY env var — passed through as Bearer auth when set
+# ---------------------------------------------------------------------------
+
+
+async def test_api_key_env_var_passed_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUDSONROCK_API_KEY", "secret-token")
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        return_value=_domain_payload(),
+    ) as mock_fetch:
+        await run_hudsonrock_osint("tesla.com")
+    assert mock_fetch.await_args.kwargs["api_key"] == "secret-token"
+
+
+async def test_api_key_empty_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HUDSONROCK_API_KEY", raising=False)
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        return_value=_domain_payload(),
+    ) as mock_fetch:
+        await run_hudsonrock_osint("tesla.com")
+    assert mock_fetch.await_args.kwargs["api_key"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Validation — short-circuit before network call
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_query_no_network_call() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        result = await run_hudsonrock_osint("   ")
+    mock_fetch.assert_not_called()
+    assert "Invalid" in result
+
+
+async def test_malformed_email_no_network_call() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        result = await run_hudsonrock_osint("user@@@")
+    mock_fetch.assert_not_called()
+    assert "Invalid" in result
+    assert "email" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Error envelope — wrapper turns exceptions into descriptive strings
+# ---------------------------------------------------------------------------
+
+
+async def test_timeout_returns_error_string() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        side_effect=asyncio.TimeoutError(),
+    ):
+        result = await run_hudsonrock_osint("tesla.com")
+    assert "timed out" in result.lower()
+
+
+async def test_network_error_returns_error_string() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        side_effect=aiohttp.ClientError("connection failed"),
+    ):
+        result = await run_hudsonrock_osint("tesla.com")
+    assert "Network error" in result
+
+
+async def test_value_error_returns_scan_error() -> None:
+    # _raise_for_status raises ValueError on 429 / non-200; verify the wrapper
+    # converts that to a "Scan error" string instead of propagating.
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Hudson Rock: rate limit exceeded (50 req / 10s)."),
+    ):
+        result = await run_hudsonrock_osint("tesla.com")
+    assert "Scan error" in result
+    assert "rate limit" in result.lower()
+
+
+async def test_unexpected_error_returns_internal_error() -> None:
+    with patch(
+        "openosint.tools.search_hudsonrock._fetch_hudsonrock",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        result = await run_hudsonrock_osint("tesla.com")
+    assert "Internal error" in result


### PR DESCRIPTION
## Summary

Adds **`search_hudsonrock`**, a new OSINT tool that queries [Hudson Rock's Cavalier API](https://cavalier.hudsonrock.com) for credentials exposed via infostealer malware (RedLine, Lumma, Raccoon, Vidar, StealC, …). Auto-routes by input shape — emails → `/search-by-email`, domains → `/search-by-domain`, usernames and E.164 phone numbers → `/search-by-username` — and works without an API key against the free public endpoint (50 req / 10 s rate limit). `HUDSONROCK_API_KEY`, if set, is sent as `Authorization: Bearer …` for commercial-tier access. Closes #4.

## Why

Infostealer-corpus checks fill a coverage gap that `search_breach` (HaveIBeenPwned) doesn't address: HIBP indexes credentials that have been *published as breaches*, but a substantial fraction of compromised credentials surface only in malware botnet logs that are sold privately. For email and domain investigations this materially increases recall, and the `domain` mode returns useful aggregate signals (compromised-employee count, top stealer families, victim-AV breakdown) for assessing organisational exposure.

## What's in the diff

**New tool module**
- [`openosint/tools/search_hudsonrock.py`](openosint/tools/search_hudsonrock.py) — async `run_hudsonrock_osint(query, timeout_seconds)`; `_classify()` selects the endpoint from input shape; separate formatters for the domain-aggregate response and per-record (email/username) responses; output redacts top-logins and masks victim IPs as returned by the API. Follows the project's tool-contract convention: never raises across the API boundary, returns descriptive error strings on failure.

**Interface registration** (per the integration checklist in `CONTRIBUTING.md`)
- [`openosint/agent.py`](openosint/agent.py) — Anthropic tool definition + dispatch entry in `_TOOL_MAP`; `SYSTEM_PROMPT` now suggests `search_hudsonrock` alongside `search_breach` for credential-exposure investigations.
- [`openosint/mcp_server.py`](openosint/mcp_server.py) — `Tool(...)` entry in `list_tools()` and dispatch branch; module docstring updated to reflect 17 tools.
- [`openosint/cli.py`](openosint/cli.py) — `openosint hudsonrock QUERY [-t SECONDS]` subcommand.
- [`openosint/repl.py`](openosint/repl.py) — display row in `_TOOL_INFO_ROWS`.
- [`openosint/web_server.py`](openosint/web_server.py) — `_TOOL_CATALOG` entry (Identity category) + `_RUNNERS` mapping; tool surfaces in the web UI sidebar and the AI chat tool-use path.

**Version + docs**
- Version bumped to **2.20.0** across [`openosint/__init__.py`](openosint/__init__.py), [`pyproject.toml`](pyproject.toml), and [`.mcp/server.json`](.mcp/server.json) (both the top-level `version` and the package entry).
- README footer was at 2.19.0 and is now in sync with the rest. `_VERSION` in `web_server.py` was already at 2.20.0.
- [`.env.example`](.env.example): new `HUDSONROCK_API_KEY` entry with a comment explaining the public-vs-commercial-tier behavior.
- [`README.md`](README.md): feature line (`16 tools` → `17`), env-var table row, Integrations table row pointing at hudsonrock.com.
- [`CHANGELOG.md`](CHANGELOG.md): `[2.20.0]` entry under `Added` / `Changed`.

**Drive-by cleanups inside the new file** (flagging transparently — happy to split into a separate commit/PR if maintainers prefer)
- `_EMAIL_RE` had `[\w-]+` in the domain class, rejecting any multi-level domain (`user@mail.example.com` failed `_is_valid_email()`). Changed to `[\w.-]+`; the TLD `[a-z]{2,}` anchor and `re.IGNORECASE` flag are preserved. Note: the same flaw exists at [`openosint/web_server.py:757`](openosint/web_server.py#L757) inside `_demo_chat_stream` — left untouched here to keep this PR scoped to the integration; can be a follow-up.
- `_fetch_hudsonrock` previously called `_raise_for_status(resp.status)` and then re-checked `resp.status == 404` to return `{}`. The two checks were redundant: `_raise_for_status` silently `return`ed on 404, then the caller detected 404 again. Collapsed into a single explicit 404 short-circuit in the caller; `_raise_for_status` now only raises, matching its name.

## Test plan

```bash
# unit tests for the new tool — 25 tests
pytest tests/test_hudsonrock.py -v

# full suite, confirming no regression
pytest
# → 233 passed, 2 skipped (the 2 skipped depend on optional binaries)

# lint + format
ruff check openosint/      # → All checks passed!
ruff format --check openosint/   # → 31 files already formatted

# manual smoke against each interface
openosint hudsonrock user@example.com         # CLI, email shape
openosint hudsonrock example.com              # CLI, domain shape
openosint hudsonrock johndoe                  # CLI, username shape
openosint hudsonrock +14155552671             # CLI, phone-as-username shape
openosint                                     # then in REPL: "check infostealer exposure for example.com"
openosint web                                 # exercise via the web UI tool card and AI chat
python openosint/mcp_server.py                # invoke search_hudsonrock from an MCP client (Claude Desktop / Claude Code)