### PR TITLE
fix(web): make OpenAI-compatible backend usable from the UI

### DIFF
--- a/openosint/web/index.html
+++ b/openosint/web/index.html
@@ -192,23 +192,27 @@
       </p>
       <div>
         <label class="text-muted text-xs uppercase tracking-wider block mb-1.5">Base URL</label>
-        <input x-model="settings.openaiBaseUrl" placeholder="http://localhost:4000/v1"
+        <input x-model="settings.openaiBaseUrl" @change="saveLocalSettings()" placeholder="http://localhost:4000/v1"
                class="w-full bg-surface border border-app rounded-md px-3 py-2 text-sm text-primary focus:outline-none transition-colors">
       </div>
       <div>
         <label class="text-muted text-xs uppercase tracking-wider block mb-1.5">Model name</label>
-        <input x-model="settings.openaiModel" placeholder="gpt-4o-mini"
+        <input x-model="settings.openaiModel" @change="saveLocalSettings()" placeholder="gpt-4o-mini"
                class="w-full bg-surface border border-app rounded-md px-3 py-2 text-sm text-primary focus:outline-none transition-colors">
       </div>
       <div>
         <label class="text-muted text-xs uppercase tracking-wider block mb-1.5">API key (optional)</label>
-        <input x-model="settings.openaiApiKey" type="password" placeholder="sk-..."
+        <input x-model="settings.openaiApiKey" @change="saveLocalSettings()" type="password" placeholder="sk-..."
                class="w-full bg-surface border border-app rounded-md px-3 py-2 text-sm text-primary focus:outline-none transition-colors">
       </div>
       <div class="flex items-center gap-3">
         <button @click="testOpenai()"
                 class="px-3 py-1.5 rounded-md border border-app text-secondary hover:text-primary text-xs transition-all">
           Test connection
+        </button>
+        <button @click="saveOpenai()"
+                class="px-3 py-1.5 rounded-md border border-app text-secondary hover:text-primary text-xs transition-all">
+          Save
         </button>
         <span x-show="openaiTestResult" x-text="openaiTestResult"
               :class="openaiTestOk ? 'text-accent' : 'text-error'"
@@ -920,25 +924,61 @@ document.addEventListener('alpine:init', () => {
     async testOpenai() {
       this.openaiTestResult = 'Testing...';
       this.openaiTestOk = false;
-      const base = (this.settings.openaiBaseUrl || '').replace(/\/$/, '');
-      if (!base) {
-        // No URL entered — fall back to the server-side check of the configured endpoint.
-        try {
-          const r = await fetch('/api/chat/test', { signal: AbortSignal.timeout(4000) });
-          const d = await r.json();
-          if (d.backend === 'openai') { this.openaiTestOk = true; this.openaiTestResult = 'Connected (server default)'; }
-          else { this.openaiTestResult = 'No endpoint configured'; }
-        } catch (e) { this.openaiTestResult = e.message; }
+      // Probe through the server: the browser cannot reach an http:// endpoint
+      // from an https:// page (mixed-content) and cross-origin requests fail
+      // CORS. The server has no such restriction. Blank fields fall back to the
+      // server's configured OPENAI_BASE_URL / OPENAI_API_KEY.
+      try {
+        const r = await fetch('/api/openai/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            openai_base_url: this.settings.openaiBaseUrl,
+            openai_api_key: this.settings.openaiApiKey,
+          }),
+          signal: AbortSignal.timeout(6000),
+        });
+        const d = await r.json();
+        if (!d.reachable) {
+          this.openaiTestResult = 'Unreachable — check Base URL / that the endpoint is running';
+        } else if (d.auth_ok) {
+          this.openaiTestOk = true; this.openaiTestResult = 'Connected';
+        } else {
+          // Endpoint is up but rejected the key — the most common real-world case.
+          this.openaiTestResult = `Endpoint reachable but key rejected (HTTP ${d.status_code}). Check API key.`;
+        }
+      } catch (e) {
+        this.openaiTestResult = e.message;
+      }
+    },
+
+    async saveOpenai() {
+      this.openaiTestResult = 'Saving...';
+      this.openaiTestOk = false;
+      // Persist to localStorage (per-request payload) AND to the server .env so
+      // the configuration survives reloads and is used as the env default.
+      this.settings.chatModel = 'openai';
+      this.saveLocalSettings();
+      const body = {};
+      if ((this.settings.openaiBaseUrl || '').trim()) body.OPENAI_BASE_URL = this.settings.openaiBaseUrl.trim();
+      if ((this.settings.openaiModel   || '').trim()) body.OPENAI_MODEL    = this.settings.openaiModel.trim();
+      if ((this.settings.openaiApiKey  || '').trim()) body.OPENAI_API_KEY  = this.settings.openaiApiKey.trim();
+      if (!Object.keys(body).length) {
+        this.openaiTestResult = 'Enter a Base URL first.';
         return;
       }
       try {
-        const headers = {};
-        if (this.settings.openaiApiKey) headers['Authorization'] = 'Bearer ' + this.settings.openaiApiKey;
-        const r = await fetch(base + '/models', { headers, signal: AbortSignal.timeout(4000) });
-        if (r.ok) { this.openaiTestOk = true; this.openaiTestResult = 'Connected'; }
-        else      { this.openaiTestResult = `HTTP ${r.status}`; }
+        const r = await fetch('/api/setup', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!r.ok) throw new Error('Save failed');
+        this.openaiTestOk = true; this.openaiTestResult = 'Saved';
+        await this.fetchHealth();
+        setTimeout(() => { if (this.openaiTestResult === 'Saved') this.openaiTestResult = ''; }, 3000);
       } catch (e) {
-        this.openaiTestResult = e.message;
+        this.openaiTestResult = e.message || 'Failed to save.';
       }
     },
   }));

--- a/openosint/web_server.py
+++ b/openosint/web_server.py
@@ -336,6 +336,41 @@ def _get_ai_backend() -> tuple[str, str | None, bool | None]:
     return ("ollama" if reachable else "none"), ollama_host, reachable
 
 
+async def _probe_openai_endpoint(base_url: str, api_key: str) -> dict:
+    """Probe an OpenAI-compatible endpoint server-side (no browser CORS / mixed-content).
+
+    Distinguishes three states so the UI can give an accurate message:
+      * unreachable      — connection failed / refused / timed out
+      * reachable + auth_ok=False — server answered but rejected the key (401/403)
+      * reachable + auth_ok=True  — server answered and accepted the key
+
+    A 401/403 still means the endpoint is *up* and usable once a valid key is
+    supplied, so we must not report it as "not configured / unreachable" — that
+    was the old bug where a healthy LiteLLM/vLLM proxy showed as backend "none".
+    """
+    base = base_url.strip().rstrip("/")
+    if not base:
+        return {"reachable": False, "auth_ok": False, "status_code": None}
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        if _httpx is not None:
+            async with _httpx.AsyncClient(timeout=2.5) as client:
+                r = await client.get(f"{base}/models", headers=headers)
+                status = r.status_code
+        else:
+            raw = await asyncio.to_thread(
+                lambda: _requests.get(f"{base}/models", headers=headers, timeout=2.5)
+            )
+            status = raw.status_code
+    except Exception:
+        return {"reachable": False, "auth_ok": False, "status_code": None}
+    return {
+        "reachable": True,
+        "auth_ok": status == 200,
+        "status_code": status,
+    }
+
+
 class RunRequest(BaseModel):
     input: str
     timeout: int = 120
@@ -349,6 +384,14 @@ class ChatRequest(BaseModel):
     ollama_host: str = "http://localhost:11434"
     openai_base_url: str = ""
     openai_model: str = ""
+    openai_api_key: str = ""
+
+
+class OpenAITestRequest(BaseModel):
+    """Body for POST /api/openai/test — all fields optional; blanks fall back
+    to the server's OPENAI_BASE_URL / OPENAI_API_KEY env vars."""
+
+    openai_base_url: str = ""
     openai_api_key: str = ""
 
 
@@ -1033,23 +1076,16 @@ def create_app() -> FastAPI:
         openai_base = os.environ.get("OPENAI_BASE_URL", "").strip().rstrip("/")
         if openai_base:
             api_key = os.environ.get("OPENAI_API_KEY", "").strip()
-            headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-            try:
-                if _httpx is not None:
-                    async with _httpx.AsyncClient(timeout=2.5) as client:
-                        r = await client.get(f"{openai_base}/models", headers=headers)
-                        reachable = r.status_code == 200
-                else:
-                    raw = await asyncio.to_thread(
-                        lambda: _requests.get(f"{openai_base}/models", headers=headers, timeout=2.5)
-                    )
-                    reachable = raw.status_code == 200
-            except Exception:
-                reachable = False
+            probe = await _probe_openai_endpoint(openai_base, api_key)
+            # Reachable means the backend is configured & answering, even if the
+            # key is rejected (401/403) — the chat path will surface the auth
+            # error clearly rather than being silently blocked as "none".
             return {
                 "status": "ok",
-                "backend": "openai" if reachable else "none",
-                "openai_reachable": reachable,
+                "backend": "openai" if probe["reachable"] else "none",
+                "openai_reachable": probe["reachable"],
+                "openai_auth_ok": probe["auth_ok"],
+                "openai_status_code": probe["status_code"],
                 "openai_base_url": openai_base,
             }
 
@@ -1072,6 +1108,22 @@ def create_app() -> FastAPI:
             "backend": "ollama" if reachable else "none",
             "ollama_reachable": reachable,
         }
+
+    # ------------------------------------------------------------------
+    # POST /api/openai/test — probe an OpenAI-compatible endpoint from the
+    # server (the browser cannot: an http:// endpoint is blocked as
+    # mixed-content from the https:// UI, and cross-origin requests fail CORS).
+    # Accepts the values typed in Settings so the user can test before saving.
+    # ------------------------------------------------------------------
+
+    @app.post("/api/openai/test")
+    async def openai_test(req: OpenAITestRequest):
+        base_url = (req.openai_base_url or os.environ.get("OPENAI_BASE_URL", "")).strip()
+        api_key = (req.openai_api_key or os.environ.get("OPENAI_API_KEY", "")).strip()
+        if not base_url:
+            return {"status": "ok", "reachable": False, "auth_ok": False, "status_code": None}
+        probe = await _probe_openai_endpoint(base_url, api_key)
+        return {"status": "ok", **probe, "openai_base_url": base_url.rstrip("/")}
 
     # ------------------------------------------------------------------
     # POST /api/chat  — AI chat with tool_use, SSE streaming

--- a/tests/test_web_server_openai.py
+++ b/tests/test_web_server_openai.py
@@ -654,3 +654,95 @@ class TestStreamOpenaiHttpxPath:
 
         assert events[0]["type"] == "error"
         assert "503" in events[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# _probe_openai_endpoint — server-side connectivity probe
+# ---------------------------------------------------------------------------
+
+
+class TestProbeOpenaiEndpoint:
+    """Probe must distinguish unreachable / reachable-but-unauthorized / ok.
+
+    Regression guard for the PR #8 bug where a healthy LiteLLM/vLLM proxy that
+    returns 401 on /models was reported as backend 'none' (unreachable),
+    blocking chat even though the endpoint was up.
+    """
+
+    async def test_empty_base_url_is_unreachable(self):
+        from openosint.web_server import _probe_openai_endpoint
+
+        result = await _probe_openai_endpoint("", "")
+        assert result == {"reachable": False, "auth_ok": False, "status_code": None}
+
+    async def test_200_is_reachable_and_auth_ok(self):
+        from openosint.web_server import _probe_openai_endpoint
+
+        with patch("openosint.web_server._httpx", None):
+            with patch("openosint.web_server._requests") as mreq:
+                mreq.get.return_value = _mock_requests_response(status_code=200, body={"data": []})
+                result = await _probe_openai_endpoint("http://localhost:4000/v1", "sk-key")
+
+        assert result["reachable"] is True
+        assert result["auth_ok"] is True
+        assert result["status_code"] == 200
+
+    async def test_401_is_reachable_but_not_auth_ok(self):
+        from openosint.web_server import _probe_openai_endpoint
+
+        with patch("openosint.web_server._httpx", None):
+            with patch("openosint.web_server._requests") as mreq:
+                mreq.get.return_value = _mock_requests_response(status_code=401, body={"error": "bad key"})
+                result = await _probe_openai_endpoint("http://localhost:4000/v1", "sk-stale")
+
+        assert result["reachable"] is True
+        assert result["auth_ok"] is False
+        assert result["status_code"] == 401
+
+    async def test_connection_error_is_unreachable(self):
+        from openosint.web_server import _probe_openai_endpoint
+
+        with patch("openosint.web_server._httpx", None):
+            with patch("openosint.web_server._requests") as mreq:
+                mreq.get.side_effect = ConnectionError("refused")
+                result = await _probe_openai_endpoint("http://10.0.0.9:4000/v1", "")
+
+        assert result["reachable"] is False
+        assert result["auth_ok"] is False
+        assert result["status_code"] is None
+
+    async def test_bearer_header_sent_when_key_present(self):
+        from openosint.web_server import _probe_openai_endpoint
+
+        with patch("openosint.web_server._httpx", None):
+            with patch("openosint.web_server._requests") as mreq:
+                mreq.get.return_value = _mock_requests_response(status_code=200, body={})
+                await _probe_openai_endpoint("http://localhost:4000/v1", "sk-abc")
+
+        _, kwargs = mreq.get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer sk-abc"
+
+
+# ---------------------------------------------------------------------------
+# OpenAITestRequest — body model for POST /api/openai/test
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAITestRequestModel:
+    """Regression guard: the /api/openai/test body must NOT require a 'message'
+    field. It originally reused ChatRequest (message required), so the Settings
+    'Test connection' POST returned 422."""
+
+    def test_validates_with_no_fields(self):
+        from openosint.web_server import OpenAITestRequest
+
+        req = OpenAITestRequest()
+        assert req.openai_base_url == ""
+        assert req.openai_api_key == ""
+
+    def test_accepts_partial_body(self):
+        from openosint.web_server import OpenAITestRequest
+
+        req = OpenAITestRequest(openai_base_url="http://localhost:4000/v1")
+        assert req.openai_base_url == "http://localhost:4000/v1"
+        assert req.openai_api_key == ""


### PR DESCRIPTION
## Summary

PR #8 added the OpenAI-compatible streaming backend (`_stream_openai`), but the web Settings UI was never wired up to it, leaving the feature effectively unusable from the browser. This fixes three concrete gaps reported in practice against a LiteLLM proxy.

### 1. OpenAI config could not be saved
The Settings → OpenAI panel had a **Test connection** button but **no Save**, and its inputs never persisted. `/api/setup` (`saveApiKeys`) only knew about `ANTHROPIC_API_KEY` + service keys, so:
- typing a Base URL / Model / Key and reloading lost everything, and
- the form still demanded an Anthropic key, making an **OpenAI-only** setup impossible.

Added a **Save** button + `saveOpenai()` that persists `OPENAI_BASE_URL` / `OPENAI_MODEL` / `OPENAI_API_KEY` to `.env` via `/api/setup`, plus `@change` persistence on the inputs. No Anthropic key required.

### 2. "Test connection" failed even against healthy endpoints
The browser fetched the `http://` endpoint **directly**, which an `https://` page blocks as mixed-content (and cross-origin fails CORS) — so the test always errored regardless of endpoint health. Routed it through a new server-side **`POST /api/openai/test`** instead.

### 3. A reachable endpoint returning 401 was reported as "none" and silently blocked chat
Both `/api/chat/test` and the browser test gated "reachable" on `GET /v1/models == 200`. A healthy LiteLLM/vLLM proxy that returns **401** on `/models` for a stale/missing key was therefore reported as backend `none`, blocking chat with a misleading "no backend configured" message.

Added `_probe_openai_endpoint()` which distinguishes three states:
- **unreachable** (connection failed)
- **reachable but `auth_ok=False`** (endpoint up, key rejected — most common real-world case)
- **reachable + `auth_ok=True`**

`/api/chat/test` now returns `backend: "openai"` with `openai_auth_ok` / `openai_status_code` whenever the endpoint answers, and the UI surfaces *"reachable but key rejected (HTTP 401). Check API key."* instead of failing silently.

## Testing
- New `TestProbeOpenaiEndpoint` (5 cases) + `TestOpenAITestRequestModel` (2 cases).
- Full suite: **279 passed**.
- Verified live against a LiteLLM proxy: stale key → "reachable but key rejected (HTTP 401)"; valid key → "Connected"; full UI → `/api/chat` → endpoint round-trip returns model output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)