### PR TITLE
fix(security): require auth on /api/setup, allowlist keys, restrict b…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
 # OPENAI_MODEL=gpt-4o-mini
 
+# Optional — required to let POST /api/setup be called from a non-localhost
+# caller (e.g. a public web deployment). Leave unset to keep /api/setup
+# localhost-only. If set, remote callers must send it as X-Setup-Token.
+# OPENOSINT_SETUP_TOKEN=
+
 # Optional — data breach checks
 HIBP_API_KEY=your_key
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ RUN mkdir -p /app/reports
 
 EXPOSE 8080
 
-CMD ["openosint", "web", "--host", "0.0.0.0", "--port", "8080", "--no-browser"]
+# --allow-remote is required for a non-loopback bind (GHSA-cqr4-hcfp-m6m4) —
+# safe here because the container network boundary is what's actually
+# exposed; publish the port only to trusted networks.
+CMD ["openosint", "web", "--host", "0.0.0.0", "--port", "8080", "--no-browser", "--allow-remote"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn openosint.web_server:create_app --factory --host 0.0.0.0 --port $PORT
+web: openosint web --host 0.0.0.0 --port $PORT --no-browser --allow-remote

--- a/openosint/cli.py
+++ b/openosint/cli.py
@@ -488,15 +488,24 @@ def _build_parser() -> argparse.ArgumentParser:
     web_cmd.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
+        default="127.0.0.1",
         metavar="HOST",
-        help="Host/IP to bind to (default: 0.0.0.0).",
+        help="Host/IP to bind to (default: 127.0.0.1, localhost-only).",
     )
     web_cmd.add_argument(
         "--no-browser",
         action="store_true",
         dest="no_browser",
         help="Do not open a browser tab automatically.",
+    )
+    web_cmd.add_argument(
+        "--allow-remote",
+        action="store_true",
+        dest="allow_remote",
+        help=(
+            "Required to bind to a non-loopback host (e.g. 0.0.0.0). "
+            "Exposes /api/setup and every other route to the network."
+        ),
     )
 
     # prompts
@@ -872,9 +881,10 @@ def _handle_sponsors() -> None:
 
 
 async def _handle_web(
-    host: str = "0.0.0.0",
+    host: str = "127.0.0.1",
     port: int = 8080,
     no_browser: bool = False,
+    allow_remote: bool = False,
 ) -> None:
     import threading
     import webbrowser
@@ -886,7 +896,7 @@ async def _handle_web(
         url = f"http://{display}:{port}"
         threading.Timer(1.5, lambda: webbrowser.open(url)).start()
 
-    await serve_async(host=host, port=port)
+    await serve_async(host=host, port=port, allow_remote=allow_remote)
 
 
 # ---------------------------------------------------------------------------
@@ -1043,9 +1053,10 @@ async def _async_main() -> None:
         )
     elif args.command == "web":
         await _handle_web(
-            host=getattr(args, "host", "0.0.0.0"),
+            host=getattr(args, "host", "127.0.0.1"),
             port=getattr(args, "port", 8080),
             no_browser=getattr(args, "no_browser", False),
+            allow_remote=getattr(args, "allow_remote", False),
         )
     elif args.command == "history":
         _handle_history(args)

--- a/openosint/web_server.py
+++ b/openosint/web_server.py
@@ -9,7 +9,7 @@ Routes:
   POST /api/run/{tool_name}    run tool, return full result
   GET  /api/stream/{tool_name} stream output via Server-Sent Events
   POST /api/chat               AI chat with tool_use (SSE)
-  POST /api/setup              save API keys to .env
+  POST /api/setup              save API keys to .env (localhost only)
   GET  /docs/*                 docs/ static files (mounted)
 """
 
@@ -19,11 +19,13 @@ import asyncio
 import json
 import os
 import re
+import secrets
 import shutil
 import time
 from collections import deque as _deque
 from pathlib import Path
 from typing import AsyncIterator
+from urllib.parse import urlparse as _urlparse
 
 import requests as _requests
 
@@ -100,6 +102,43 @@ _RL_MAX_REQS: int = int(os.getenv("RATE_LIMIT_MAX", "30"))
 _KEYLESS_TOOLS: frozenset[str] = frozenset(
     {"search_whois", "search_dns", "generate_dorks", "search_ip", "search_paste"}
 )
+
+
+_LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1"})
+
+
+def _is_loopback_request(request: "Request") -> bool:
+    """True only for connections that actually terminate on this host.
+
+    Deliberately ignores X-Forwarded-For / CF-Connecting-IP — those are
+    attacker-controlled headers. GHSA-cqr4-hcfp-m6m4: /api/setup writes to
+    live process env vars, so it must not trust proxy headers the way the
+    keyless-tool rate limiter does.
+    """
+    return bool(request.client) and request.client.host in _LOOPBACK_HOSTS
+
+
+def _setup_request_is_authorized(request: "Request") -> bool:
+    """Gate for /api/setup that does not depend on network topology.
+
+    request.client.host reflects whatever peer terminates the TCP connection
+    to this process — on a PaaS like Heroku that's the platform's router, a
+    distinct network peer, not loopback. That's the normal case and it's
+    already rejected below. But this must not be the *only* line of defense:
+    a future deploy behind an on-host reverse proxy (nginx sidecar, buildpack,
+    etc.) would make the router's connection look like loopback and silently
+    reopen GHSA-cqr4-hcfp-m6m4. So a loopback caller is always allowed (the
+    single-user local CLI case), and a non-loopback caller is allowed only if
+    it presents a token matching OPENOSINT_SETUP_TOKEN — which is unset by
+    default, so remote /api/setup is off unless an operator opts in.
+    """
+    if _is_loopback_request(request):
+        return True
+    expected = os.environ.get("OPENOSINT_SETUP_TOKEN", "").strip()
+    if not expected:
+        return False
+    supplied = request.headers.get("X-Setup-Token", "")
+    return secrets.compare_digest(supplied, expected)
 
 
 def _get_client_ip(request: "Request") -> str:
@@ -495,6 +534,26 @@ _KNOWN_ENV_KEYS = [
     "BRIGHTDATA_SERP_ZONE",
     "BRIGHTDATA_UNLOCKER_ZONE",
 ]
+
+# Keys /api/setup is allowed to write. Anything else in the request body is
+# dropped — GHSA-cqr4-hcfp-m6m4 let a caller set arbitrary env vars (e.g.
+# OPENAI_BASE_URL) this way, redirecting outbound chat traffic and its auth
+# header to attacker infra.
+_SETUP_ALLOWED_KEYS: frozenset[str] = frozenset(_KNOWN_ENV_KEYS) | {
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL",
+    "OPENAI_API_KEY",
+}
+
+# Keys whose value must be a well-formed http(s) URL — prevents javascript:/
+# file:/gopher: schemes or bare hostnames sneaking into a *_BASE_URL var that
+# later gets used to build outbound requests.
+_SETUP_URL_KEYS: frozenset[str] = frozenset({"OPENAI_BASE_URL"})
+
+
+def _is_valid_base_url(value: str) -> bool:
+    parsed = _urlparse(value)
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
 
 
 def _is_setup_complete() -> bool:
@@ -1425,6 +1484,18 @@ def create_app() -> FastAPI:
 
     @app.post("/api/setup")
     async def setup(request: Request):
+        # GHSA-cqr4-hcfp-m6m4: this endpoint writes to live process env vars
+        # and .env, so it must never be reachable from the network. Loopback
+        # callers are always allowed; anyone else needs OPENOSINT_SETUP_TOKEN.
+        if not _setup_request_is_authorized(request):
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "message": "Setup is only allowed from localhost, or with a valid X-Setup-Token.",
+                },
+                status_code=403,
+            )
+
         body: dict = await request.json()
         env_path = _ROOT / ".env"
         existing: dict[str, str] = {}
@@ -1434,13 +1505,26 @@ def create_app() -> FastAPI:
                 if "=" in line and not line.startswith("#"):
                     k, _, v = line.partition("=")
                     existing[k.strip()] = v.strip()
+
+        applied: list[str] = []
+        rejected: list[str] = []
         for k, v in body.items():
+            key = str(k).strip()
             v_str = str(v).strip()
-            if v_str:
-                existing[k.strip()] = v_str
-                os.environ[k.strip()] = v_str
+            if not v_str:
+                continue
+            if key not in _SETUP_ALLOWED_KEYS:
+                rejected.append(key)
+                continue
+            if key in _SETUP_URL_KEYS and not _is_valid_base_url(v_str):
+                rejected.append(key)
+                continue
+            existing[key] = v_str
+            os.environ[key] = v_str
+            applied.append(key)
+
         env_path.write_text("\n".join(f"{k}={v}" for k, v in existing.items()) + "\n")
-        return {"status": "ok"}
+        return {"status": "ok", "applied": applied, "rejected": rejected}
 
     # ------------------------------------------------------------------
     # POST /api/demo/chat  — pre-scripted demo stream, no API key needed
@@ -1496,8 +1580,33 @@ def create_app() -> FastAPI:
 # ---------------------------------------------------------------------------
 
 
-async def serve_async(host: str = "0.0.0.0", port: int = 8080) -> None:
+_SAFE_BIND_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _require_safe_bind(host: str, allow_remote: bool) -> None:
+    """Refuse to bind to a non-loopback interface without an explicit opt-in.
+
+    GHSA-cqr4-hcfp-m6m4: binding 0.0.0.0 by default put /api/setup (and every
+    other route) on the network unintentionally.
+    """
+    if host in _SAFE_BIND_HOSTS:
+        return
+    if allow_remote or os.environ.get("OPENOSINT_ALLOW_REMOTE", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+    raise SystemExit(
+        f"Refusing to bind to {host!r}: this exposes the server to the network. "
+        "Pass --allow-remote (or set OPENOSINT_ALLOW_REMOTE=1) if that's intended, "
+        "and put it behind a firewall/reverse proxy."
+    )
+
+
+async def serve_async(host: str = "127.0.0.1", port: int = 8080, allow_remote: bool = False) -> None:
     """Run uvicorn within an already-running asyncio event loop."""
+    _require_safe_bind(host, allow_remote)
     load_dotenv()
     app = create_app()
     _print_banner(host, port)
@@ -1506,8 +1615,9 @@ async def serve_async(host: str = "0.0.0.0", port: int = 8080) -> None:
     await server.serve()
 
 
-def run_server(host: str = "0.0.0.0", port: int = 8080) -> None:
+def run_server(host: str = "127.0.0.1", port: int = 8080, allow_remote: bool = False) -> None:
     """Standalone blocking entry point."""
+    _require_safe_bind(host, allow_remote)
     load_dotenv()
     app = create_app()
     _print_banner(host, port)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -830,6 +830,136 @@ class TestCreateAppFactoryRoutes:
         assert resp.json()["demo_mode"] is True
 
 
+class TestSetupEndpointGuards:
+    """GHSA-cqr4-hcfp-m6m4: /api/setup must reject remote callers, unknown
+    keys, and malformed *_BASE_URL values."""
+
+    async def test_loopback_caller_can_save_allowlisted_key(self, http_client, tmp_path, monkeypatch):
+        import openosint.web_server as ws
+
+        monkeypatch.setattr(ws, "_ROOT", tmp_path)
+        resp = await http_client.post("/api/setup", json={"SHODAN_API_KEY": "abc123"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["applied"] == ["SHODAN_API_KEY"]
+        assert os.environ.get("SHODAN_API_KEY") == "abc123"
+        os.environ.pop("SHODAN_API_KEY", None)
+
+    async def test_remote_caller_is_rejected_before_body_is_applied(self, tmp_path, monkeypatch):
+        import openosint.web_server as ws
+
+        monkeypatch.setattr(ws, "_ROOT", tmp_path)
+        app = ws.create_app()
+        transport = ASGITransport(app=app, client=("203.0.113.5", 12345))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post("/api/setup", json={"OPENAI_BASE_URL": "http://attacker.example/v1"})
+
+        assert resp.status_code == 403
+        assert "OPENAI_BASE_URL" not in os.environ
+        assert not (tmp_path / ".env").exists()
+
+    async def test_remote_caller_with_no_token_configured_is_rejected(self, tmp_path, monkeypatch):
+        """No OPENOSINT_SETUP_TOKEN set → remote setup stays off, even with a header."""
+        import openosint.web_server as ws
+
+        monkeypatch.setattr(ws, "_ROOT", tmp_path)
+        monkeypatch.delenv("OPENOSINT_SETUP_TOKEN", raising=False)
+        app = ws.create_app()
+        transport = ASGITransport(app=app, client=("203.0.113.5", 12345))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/setup",
+                json={"SHODAN_API_KEY": "x"},
+                headers={"X-Setup-Token": "guessed-token"},
+            )
+
+        assert resp.status_code == 403
+        assert "SHODAN_API_KEY" not in os.environ
+
+    async def test_remote_caller_with_wrong_token_is_rejected(self, tmp_path, monkeypatch):
+        import openosint.web_server as ws
+
+        monkeypatch.setattr(ws, "_ROOT", tmp_path)
+        monkeypatch.setenv("OPENOSINT_SETUP_TOKEN", "correct-token")
+        app = ws.create_app()
+        transport = ASGITransport(app=app, client=("203.0.113.5", 12345))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/setup",
+                json={"SHODAN_API_KEY": "x"},
+                headers={"X-Setup-Token": "wrong-token"},
+            )
+
+        assert resp.status_code == 403
+        assert "SHODAN_API_KEY" not in os.environ
+
+    async def test_remote_caller_with_correct_token_is_accepted(self, tmp_path, monkeypatch):
+        import openosint.web_server as ws
+
+        monkeypatch.setattr(ws, "_ROOT", tmp_path)
+        monkeypatch.setenv("OPENOSINT_SETUP_TOKEN", "correct-token")
+        app = ws.create_app()
+        transport = ASGITransport(app=app, client=("203.0.113.5", 12345))
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.post(
+                "/api/setup",
+                json={"SHODAN_API_KEY": "x"},
+                headers={"X-Setup-Token": "correct-token"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["applied"] == ["SHODAN_API_KEY"]
+        os.environ.pop("SHODAN_API_KEY", None)
+
+    async def test_non_allowlisted_key_is_dropped_not_written(self, http_client, tmp_path, monkeypatch):
+        import openosint.web_server as ws
+
+        monkeypatch.setattr(ws, "_ROOT", tmp_path)
+        resp = await http_client.post("/api/setup", json={"NOT_A_REAL_ENV_VAR": "x"})
+
+        assert resp.status_code == 200
+        assert resp.json()["rejected"] == ["NOT_A_REAL_ENV_VAR"]
+        assert "NOT_A_REAL_ENV_VAR" not in os.environ
+
+    async def test_malformed_base_url_is_rejected(self, http_client, tmp_path, monkeypatch):
+        import openosint.web_server as ws
+
+        monkeypatch.setattr(ws, "_ROOT", tmp_path)
+        resp = await http_client.post("/api/setup", json={"OPENAI_BASE_URL": "javascript:alert(1)"})
+
+        assert resp.status_code == 200
+        assert resp.json()["rejected"] == ["OPENAI_BASE_URL"]
+        assert "OPENAI_BASE_URL" not in os.environ
+
+
+class TestRequireSafeBind:
+    """GHSA-cqr4-hcfp-m6m4: non-loopback binds need an explicit opt-in."""
+
+    def test_loopback_host_is_always_allowed(self):
+        from openosint.web_server import _require_safe_bind
+
+        _require_safe_bind("127.0.0.1", allow_remote=False)  # no raise
+
+    def test_wildcard_bind_without_opt_in_raises(self, monkeypatch):
+        from openosint.web_server import _require_safe_bind
+
+        monkeypatch.delenv("OPENOSINT_ALLOW_REMOTE", raising=False)
+        with pytest.raises(SystemExit):
+            _require_safe_bind("0.0.0.0", allow_remote=False)
+
+    def test_wildcard_bind_with_allow_remote_flag_passes(self):
+        from openosint.web_server import _require_safe_bind
+
+        _require_safe_bind("0.0.0.0", allow_remote=True)  # no raise
+
+    def test_wildcard_bind_with_env_var_passes(self, monkeypatch):
+        from openosint.web_server import _require_safe_bind
+
+        monkeypatch.setenv("OPENOSINT_ALLOW_REMOTE", "1")
+        _require_safe_bind("0.0.0.0", allow_remote=False)  # no raise
+
+
 class TestApiKeysNotLogged:
     async def test_secret_key_absent_from_log_records(self, http_client, caplog):
         secret = "top-secret-key-abc123"


### PR DESCRIPTION
## Summary

Fixes **GHSA-cqr4-hcfp-m6m4**: `POST /api/setup` was reachable by any unauthenticated network caller and wrote arbitrary key/value pairs straight into `os.environ` and `.env` — including `OPENAI_BASE_URL`. A remote attacker could redirect outbound `/api/chat` traffic (and its OpenAI-compatible auth header) to attacker-controlled infrastructure.

## Fix

- **Auth gate on `/api/setup`**: loopback callers are allowed by default; any other caller needs a token matching `OPENOSINT_SETUP_TOKEN` (unset by default, so remote setup is off unless an operator opts in). This doesn't rely solely on `request.client.host` looking like loopback — it's defense-in-depth in case a future deploy sits behind an on-host reverse proxy that would make a router's connection appear local.
- **Allowlist**: replaced arbitrary key writes with an explicit set of permitted config keys (`_SETUP_ALLOWED_KEYS`). Unknown keys are dropped and reported back in the response (`rejected`).
- **URL validation**: `OPENAI_BASE_URL` must parse as a well-formed `http(s)` URL before being applied — blocks `javascript:`/bare-string values from landing in a var later used to build outbound requests.
- **Safe bind by default**: `openosint web` / `serve_async` / `run_server` now default to `127.0.0.1` and refuse to bind `0.0.0.0` (or any non-loopback host) without an explicit `--allow-remote` flag or `OPENOSINT_ALLOW_REMOTE=1`.
- **Procfile bug**: the Heroku `Procfile` was launching `uvicorn` directly against `create_app`, completely bypassing the CLI's bind guard on the live deploy. Switched it to go through `openosint web --allow-remote` so the guard actually applies.
- `Dockerfile`'s default `CMD` updated to pass `--allow-remote` explicitly (container network boundary is the actual trust boundary there).
- `.env.example` documents the new `OPENOSINT_SETUP_TOKEN` variable.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New integration (new OSINT tool or external API)
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Other (describe below)

## Test plan

- [x] `pytest tests/` — 566 passed, including 11 new tests covering: loopback allowed, remote rejected, no-token/wrong-token/correct-token paths, allowlist drops unknown keys, malformed `OPENAI_BASE_URL` rejected, `_require_safe_bind`'s four branches
- [ ] Manual smoke test on the Heroku demo after deploy — owner will handle deploy + live verification, not part of this PR

## Checklist

- [x] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, and `CLAUDE.md` — not applicable, no public API/behavior change requiring a version bump beyond the security fix
- [ ] README and docs updated where applicable — not applicable
- [ ] If adding an integration: the new tool is registered in `agent.py`, `mcp_server.py`, `cli.py`, `repl.py`, and `web_server.py` — not applicable, no new tool
- [x] `.env.example` updated for any new environment variable (`OPENOSINT_SETUP_TOKEN`)
- [x] No secrets or API keys committed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>