### PR TITLE
docs: add Operator's Playbook references across README, CLI help, web…

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,12 @@ Set `ANTHROPIC_API_KEY` (and optionally `HIBP_API_KEY`, `IPINFO_TOKEN`) in a `.e
 | DNS (system resolver) | — | `search_dns` | Community | None |
 | Google Search | https://www.google.com | `generate_dorks` | Community | None |
 
+## Learn the Method
+
+OpenOSINT is the tool. The **AI OSINT Operator's Playbook** (paid guide, $39) is the method — step-by-step workflows for running investigations with ChatGPT, Claude, and OpenOSINT.
+
+**→ [Get the Playbook](https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=github&utm_medium=readme&utm_campaign=operator_playbook)**
+
 ## Resources
 
 ### Free Starter Set
@@ -613,6 +619,8 @@ OpenOSINT gives you the tooling. The **AI OSINT Prompt Pack** gives you the meth
 - 7-page PDF · instant download · pairs directly with OpenOSINT
 
 **→ [Get the Prompt Pack ($29)](https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=github&utm_medium=readme&utm_campaign=prompt_pack)**
+
+Also available: [AI OSINT Operator's Playbook](https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=github&utm_medium=readme&utm_campaign=operator_playbook) — paid guide, $39, covering full investigation workflows.
 
 _Buying it directly funds OpenOSINT's development._
 

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -96,6 +96,7 @@
 <ul>
   <li><b><a href="/free-prompts/?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=free_starter">Free AI OSINT Prompt Starter Set</a></b> &mdash; 5 structured prompts that make ChatGPT and Claude collect real data instead of hallucinating. Free PDF, instant download, no card needed.</li>
   <li><b><a href="https://tommasodev.gumroad.com/l/ai-osint-complete-kit?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=complete_kit" target="_blank" rel="noopener">AI OSINT Complete Kit (Playbook + Prompt Pack)</a></b> &mdash; practical guide to running AI-assisted OSINT investigations, with 30+ ready-to-use prompts and the full methodology.</li>
+  <li><b><a href="https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=operator_playbook" target="_blank" rel="noopener">AI OSINT Operator's Playbook</a></b> &mdash; paid guide ($39) with step-by-step workflows for running investigations with ChatGPT, Claude, and OpenOSINT.</li>
 </ul>
 </div>
 

--- a/openosint/cli.py
+++ b/openosint/cli.py
@@ -108,6 +108,9 @@ def _build_parser() -> argparse.ArgumentParser:
             "  openosint --json email target@example.com\n"
             "  openosint --provider ollama                 # use local Ollama\n"
             "  openosint --provider ollama --ollama-model mistral\n"
+            "\n"
+            "Learn the method: AI OSINT Operator's Playbook (paid guide, $39)\n"
+            "  https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=cli&utm_medium=help&utm_campaign=operator_playbook\n"
         ),
     )
     parser.add_argument(

--- a/openosint/web/index.html
+++ b/openosint/web/index.html
@@ -363,8 +363,13 @@
     <!-- footer -->
     <div class="border-t border-app mt-4 pt-4 flex items-center justify-between">
       <span class="text-muted text-xs font-mono">OpenOSINT <span x-text="version"></span></span>
-      <a href="https://github.com/OpenOSINT/OpenOSINT" target="_blank" rel="noopener"
-         class="text-secondary hover:text-primary text-xs transition-colors">GitHub</a>
+      <div class="flex items-center gap-3">
+        <a href="https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=webui&utm_medium=footer&utm_campaign=operator_playbook"
+           target="_blank" rel="noopener" title="AI OSINT Operator's Playbook — paid guide, $39"
+           class="text-secondary hover:text-primary text-xs transition-colors">Learn the method →</a>
+        <a href="https://github.com/OpenOSINT/OpenOSINT" target="_blank" rel="noopener"
+           class="text-secondary hover:text-primary text-xs transition-colors">GitHub</a>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
… UI, and docs

Add promotional links to the AI OSINT Operator's Playbook (paid guide) in the README, CLI --help epilog, web UI footer, and docs resources page. Uses per-surface UTM parameters for conversion tracking. No changes to MCP server, REPL, agent, or any security-related files.

## Summary

<!-- What does this PR do? One to three sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New integration (new OSINT tool or external API)
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Other (describe below)

## Test plan

<!-- Steps to verify this change works correctly. -->

## Checklist

- [ ] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, and `CLAUDE.md`
- [ ] README and docs updated where applicable
- [ ] If adding an integration: the new tool is registered in `agent.py`, `mcp_server.py`, `cli.py`, `repl.py`, and `web_server.py`
- [ ] `.env.example` updated for any new environment variable
- [ ] No secrets or API keys committed
