### PR TITLE
docs: RapidProxy sponsor copy + Polar webhook debug harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,13 @@ Enhanced IP geolocation, ISP, VPN/Proxy/Tor, and datacenter detection. Powers `s
 
 **[RapidProxy](https://www.rapidproxy.io/?ref=openosint)** — Featured Integration · Residential Proxies
 
-90M+ rotating residential IPs across 200+ countries — smart rotation, geo-targeting, non-expiring traffic. 10% off with code RAPID10.
+**Reliable Residential Proxies for Data Collection & Automation**
+
+**Access 90M+ real residential IPs across 200+ countries with smart rotation, geo-targeting, high-concurrency support, and non-expiring traffic.**
+
+**Use Cases:** Web Scraping · Data Collection · AI Automation · Developer Tools
+
+🎁 10% discount with code **RAPID10** → [Start Free Testing](https://www.rapidproxy.io/?ref=openosint)
 
 <!-- SPONSORS:END -->
 

--- a/docs/sponsors.html
+++ b/docs/sponsors.html
@@ -443,7 +443,7 @@ var SPONSORS = [
     logo:        "assets/rapidproxy-logo.png",
     logo_alt:    "RapidProxy logo — residential proxy provider",
     category:    "Residential Proxies",
-    description: "90M+ rotating residential IPs across 200+ countries — smart rotation, geo-targeting, non-expiring traffic. 10% off with code RAPID10."
+    description: "<b>Reliable Residential Proxies for Data Collection &amp; Automation</b><br><br>Access 90M+ real residential IPs across 200+ countries with smart rotation, geo-targeting, high-concurrency support, and non-expiring traffic.<br><br><b>Use Cases:</b> Web Scraping &middot; Data Collection &middot; AI Automation &middot; Developer Tools<br><br>&#127873; 10% discount with code <b>RAPID10</b>"
   }
 ];
 

--- a/scripts/debug/seed_and_run.py
+++ b/scripts/debug/seed_and_run.py
@@ -1,0 +1,31 @@
+import os
+import uvicorn
+from cloud import db
+from cloud.main import app
+
+db._MEMORY_CUSTOMERS["FAKE_KEY_OK"] = db.Customer(
+    api_key="FAKE_KEY_OK",
+    polar_customer_id="polar_fake_ok",
+    credits=100,
+    plan="starter",
+)
+db._MEMORY_BY_POLAR_ID["polar_fake_ok"] = "FAKE_KEY_OK"
+
+db._MEMORY_CUSTOMERS["FAKE_KEY_TAKEN"] = db.Customer(
+    api_key="FAKE_KEY_TAKEN",
+    polar_customer_id="polar_fake_taken",
+    credits=50,
+    plan="payg",
+)
+db._MEMORY_USERS[999999] = db.User(
+    id=999999,
+    provider="synthetic",
+    provider_user_id="ghost",
+    email=None,
+    polar_customer_id="polar_fake_taken",
+    customer_api_key="FAKE_KEY_TAKEN",
+)
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/scripts/debug/sig_isolation_test.py
+++ b/scripts/debug/sig_isolation_test.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+import base64
+import hashlib
+import hmac
+import sys
+import time
+import requests
+
+_KEY = b"isolation-test-key-32-bytes!!!!"
+SECRET = "whsec_" + base64.b64encode(_KEY).decode()
+BODY = b'{"type":"checkout.updated","data":{"customer_id":"cust_isolation_test"}}'
+MSG_ID = "msg_isolation_test_001"
+
+def build_headers(body: bytes) -> dict[str, str]:
+    msg_timestamp = str(int(time.time()))
+    signed_content = f"{MSG_ID}.{msg_timestamp}.".encode() + body
+    sig = base64.b64encode(hmac.new(_KEY, signed_content, hashlib.sha256).digest()).decode()
+    return {
+        "Content-Type": "application/json",
+        "webhook-id": MSG_ID,
+        "webhook-timestamp": msg_timestamp,
+        "webhook-signature": f"v1,{sig}",
+    }
+
+def post(label: str, url: str) -> None:
+    headers = build_headers(BODY)
+    print(f"\n--- {label}: {url} ---")
+    print(f"body bytes sent ({len(BODY)}): {BODY!r}")
+    try:
+        resp = requests.post(url, data=BODY, headers=headers, timeout=10)
+        print(f"status: {resp.status_code}")
+        print(f"response body: {resp.text}")
+    except Exception as exc:
+        print(f"REQUEST FAILED: {exc!r}")
+
+def main() -> None:
+    print(f"POLAR_WEBHOOK_SECRET to use in T1:\n  {SECRET}\n")
+    print("Restart T1 with that value set, THEN press Enter to continue.")
+    input()
+    post("LOCAL", "http://localhost:8000/v1/polar/webhook")
+    if len(sys.argv) > 1:
+        tunnel_url = sys.argv[1].rstrip("/") + "/v1/polar/webhook"
+        post("TUNNEL", tunnel_url)
+    else:
+        print("\nNo tunnel URL passed.")
+
+if __name__ == "__main__":
+    main()

--- a/sponsors.json
+++ b/sponsors.json
@@ -11,7 +11,7 @@
   },
   {
     "name": "RapidProxy",
-    "tagline": "90M+ rotating residential IPs across 200+ countries — smart rotation & geo-targeting.",
+    "tagline": "Reliable Residential Proxies for Data Collection & Automation — 90M+ IPs across 200+ countries. 10% off: RAPID10.",
     "url": "https://www.rapidproxy.io/?ref=openosint",
     "logo": "https://raw.githubusercontent.com/OpenOSINT/OpenOSINT/main/docs/assets/rapidproxy-logo.png",
     "tier": "featured",


### PR DESCRIPTION
## Summary
- Updates the RapidProxy Featured Integration placement (README + website card) to match the sponsor's approved final copy (headline, use cases, RAPID10 discount), on top of the logo/link update already merged via #20.
- Adds two local debug scripts (`scripts/debug/seed_and_run.py`, `scripts/debug/sig_isolation_test.py`) used to isolate the Polar webhook HMAC signature-mismatch issue — both use fully synthetic fixtures, no real keys or customer data.

## Test plan
- [ ] Render README.md on GitHub and confirm the RapidProxy sponsor block displays correctly
- [ ] Confirm docs/sponsors.html card renders the new copy without breaking layout
- [ ] `python scripts/debug/sig_isolation_test.py` runs locally against a dev server without errors