### PR TITLE
docs: move RapidProxy full sponsor copy under the Sponsors grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ openosint > investigate target@example.com
 </tr>
 </table>
 
+**Reliable Residential Proxies for Data Collection & Automation**
+
+**Access 90M+ real residential IPs across 200+ countries with smart rotation, geo-targeting, high-concurrency support, and non-expiring traffic.**
+
+**Use Cases:** Web Scraping · Data Collection · AI Automation · Developer Tools
+
+🎁 10% discount with code **RAPID10** → [Start Free Testing](https://www.rapidproxy.io/?ref=openosint)
+
 ## Custom Integrations
 
 Need OpenOSINT wired into your SOC, fraud, threat-intel, or AI-agent stack?
@@ -661,14 +669,6 @@ Enhanced IP geolocation, ISP, VPN/Proxy/Tor, and datacenter detection. Powers `s
 </a>
 
 **[RapidProxy](https://www.rapidproxy.io/?ref=openosint)** — Featured Integration · Residential Proxies
-
-**Reliable Residential Proxies for Data Collection & Automation**
-
-**Access 90M+ real residential IPs across 200+ countries with smart rotation, geo-targeting, high-concurrency support, and non-expiring traffic.**
-
-**Use Cases:** Web Scraping · Data Collection · AI Automation · Developer Tools
-
-🎁 10% discount with code **RAPID10** → [Start Free Testing](https://www.rapidproxy.io/?ref=openosint)
 
 <!-- SPONSORS:END -->
 


### PR DESCRIPTION
The RAPID10 copy (headline, Use Cases line, discount CTA) previously only existed in the Current sponsors block near the bottom of the README, disconnected from the compact Sponsors grid most visitors see. Moves it directly under the grid so the full placement is visible where the sponsor expects it.

## Summary

<!-- What does this PR do? One to three sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New integration (new OSINT tool or external API)
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Other (describe below)

## Test plan

<!-- Steps to verify this change works correctly. -->

## Checklist

- [ ] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, and `CLAUDE.md`
- [ ] README and docs updated where applicable
- [ ] If adding an integration: the new tool is registered in `agent.py`, `mcp_server.py`, `cli.py`, `repl.py`, and `web_server.py`
- [ ] `.env.example` updated for any new environment variable
- [ ] No secrets or API keys committed
