### PR TITLE
feat: global upstream-proxy support for web-facing tools (HTTP/SOCKS5)

### DIFF
--- a/openosint/cli.py
+++ b/openosint/cli.py
@@ -32,20 +32,28 @@ import os  # noqa: E402
 import sys  # noqa: E402
 
 from openosint.json_output import format_tool_result  # noqa: E402
+from openosint.proxy import (  # noqa: E402
+    ProxyConfigError,
+    get_proxy_url,
+    redact_proxy_url,
+    set_cli_proxy_url,
+)
 from openosint.tools.scrape_url import run_scrape_url_osint  # noqa: E402
-from openosint.tools.search_footprint import run_footprint_osint  # noqa: E402
 from openosint.tools.search_abuseipdb import run_abuseipdb_osint  # noqa: E402
 from openosint.tools.search_breach import run_breach_osint  # noqa: E402
 from openosint.tools.search_censys import run_censys_osint  # noqa: E402
 from openosint.tools.search_dns import run_dns_osint  # noqa: E402
 from openosint.tools.search_dorks_live import run_dorks_live_osint  # noqa: E402
 from openosint.tools.search_email import run_email_osint  # noqa: E402
+from openosint.tools.search_footprint import run_footprint_osint  # noqa: E402
 from openosint.tools.search_github import run_github_osint  # noqa: E402
 from openosint.tools.search_ip2location import run_ip2location_osint  # noqa: E402
 from openosint.tools.search_paste import run_paste_osint  # noqa: E402
 from openosint.tools.search_shodan import run_shodan_osint  # noqa: E402
 from openosint.tools.search_username import run_username_osint  # noqa: E402
 from openosint.tools.search_virustotal import run_virustotal_osint  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 _DIVIDER = "=" * 60
 
@@ -108,6 +116,8 @@ def _build_parser() -> argparse.ArgumentParser:
             "  openosint --json email target@example.com\n"
             "  openosint --provider ollama                 # use local Ollama\n"
             "  openosint --provider ollama --ollama-model mistral\n"
+            "  openosint --proxy socks5://user:pass@host:1080 email target@example.com\n"
+            "  openosint proxy-test                        # verify the configured proxy\n"
             "\n"
             "Learn the method: AI OSINT Operator's Playbook (paid guide, $39)\n"
             "  https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=cli&utm_medium=help&utm_campaign=operator_playbook\n"
@@ -199,6 +209,17 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="is_pdf_disabled",
         help="Disable automatic PDF generation alongside Markdown reports.",
+    )
+    parser.add_argument(
+        "--proxy",
+        type=str,
+        default=None,
+        metavar="URL",
+        help=(
+            "Upstream proxy for web-facing tools (http://, https://, or socks5://). "
+            "Overrides OPENOSINT_PROXY_URL. Excludes DNS lookups, generate_dorks, "
+            "the Anthropic client, and the Bright Data tools (scrape/footprint/search-dorks-live)."
+        ),
     )
 
     subparsers = parser.add_subparsers(dest="command", metavar="command")
@@ -509,6 +530,12 @@ def _build_parser() -> argparse.ArgumentParser:
             "Required to bind to a non-loopback host (e.g. 0.0.0.0). "
             "Exposes /api/setup and every other route to the network."
         ),
+    )
+
+    # proxy-test
+    subparsers.add_parser(
+        "proxy-test",
+        help="Verify the configured upstream proxy by fetching your exit IP.",
     )
 
     # prompts
@@ -841,6 +868,42 @@ async def _handle_multi(
 
 
 # ---------------------------------------------------------------------------
+# Proxy-test command handler
+# ---------------------------------------------------------------------------
+
+_IP_ECHO_URL = "https://api.ipify.org"
+
+
+def _handle_proxy_test() -> None:
+    import requests
+
+    from openosint.proxy import get_requests_proxies
+
+    proxy_url = get_proxy_url()
+    if proxy_url:
+        print(f"[*] Testing proxy: {redact_proxy_url(proxy_url)}", file=sys.stderr)
+    else:
+        print(
+            "[*] No proxy configured (--proxy / OPENOSINT_PROXY_URL unset) — "
+            "testing direct connection.",
+            file=sys.stderr,
+        )
+    try:
+        response = requests.get(
+            _IP_ECHO_URL,
+            params={"format": "json"},
+            timeout=15,
+            proxies=get_requests_proxies(),
+        )
+        response.raise_for_status()
+        exit_ip = response.json().get("ip", "unknown")
+        print(f"[+] Exit IP: {exit_ip}")
+    except requests.RequestException as exc:
+        print(f"[!] Proxy test failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
 # Sponsors command handler
 # ---------------------------------------------------------------------------
 
@@ -961,6 +1024,15 @@ async def _async_main() -> None:
     args = parser.parse_args()
     _configure_logging(args.verbose)
 
+    set_cli_proxy_url(getattr(args, "proxy", None))
+    try:
+        proxy_url = get_proxy_url()
+    except ProxyConfigError as exc:
+        print(f"[!] Proxy configuration error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if proxy_url:
+        print(f"[*] Upstream proxy active: {redact_proxy_url(proxy_url)}", file=sys.stderr)
+
     # No subcommand or explicit 'shell' → launch REPL.
     # Await directly — run_repl() is a sync wrapper that calls asyncio.run()
     # internally, which raises RuntimeError when called from a running event loop.
@@ -1065,6 +1137,8 @@ async def _async_main() -> None:
         _handle_history(args)
     elif args.command == "sponsors":
         _handle_sponsors()
+    elif args.command == "proxy-test":
+        _handle_proxy_test()
     elif args.command == "prompts":
         print(
             "AI OSINT Prompt Pack — 30+ structured prompts for AI-assisted OSINT.\n"

--- a/openosint/proxy.py
+++ b/openosint/proxy.py
@@ -1,0 +1,141 @@
+# openosint/proxy.py
+"""
+Global upstream-proxy configuration.
+
+Precedence: --proxy CLI flag > OPENOSINT_PROXY_URL env var > unset (no proxy).
+
+Excluded by design (see CLAUDE.md investigation notes):
+  - search_dns: raw DNS resolution, not proxyable via HTTP/SOCKS.
+  - generate_dorks: no network call.
+  - the Anthropic client (agent.py): LLM API traffic, not target-facing OSINT
+    traffic — proxying it adds latency/cost and exposes prompt content to a
+    third party for no benefit.
+  - scrape_url, search_dorks_live, search_footprint: all three call Bright
+    Data's own API. Bright Data is already the unlocker/residential-network
+    layer; a second proxy in front of that API call doesn't touch the actual
+    target-fetch (Bright Data does that server-side) and is a redundant hop.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit, urlunsplit
+
+_ENV_VAR = "OPENOSINT_PROXY_URL"
+_SOCKS_INSTALL_HINT = "SOCKS proxy requires: pip install openosint[socks]"
+_SUPPORTED_SCHEMES = ("http", "https", "socks5", "socks5h")
+
+_cli_proxy_url: str | None = None
+
+
+class ProxyConfigError(Exception):
+    """Raised when the configured proxy URL has an unsupported scheme or a missing extra."""
+
+
+def set_cli_proxy_url(url: str | None) -> None:
+    """Register the --proxy CLI flag value. Call once at startup."""
+    global _cli_proxy_url
+    _cli_proxy_url = url or None
+
+
+def _is_socks(url: str) -> bool:
+    return urlsplit(url).scheme.lower().startswith("socks5")
+
+
+def _validate(url: str) -> None:
+    scheme = urlsplit(url).scheme.lower()
+    if scheme not in _SUPPORTED_SCHEMES:
+        raise ProxyConfigError(
+            f"Unsupported proxy scheme '{scheme}://'. Use http://, https://, or socks5://."
+        )
+    if _is_socks(url):
+        try:
+            import socks  # noqa: F401  (pysocks — required by requests/urllib3 for SOCKS)
+        except ImportError as exc:
+            raise ProxyConfigError(_SOCKS_INSTALL_HINT) from exc
+
+
+def get_proxy_url() -> str | None:
+    """Return the effective proxy URL: CLI flag > env var > None."""
+    url = _cli_proxy_url or os.environ.get(_ENV_VAR) or None
+    if url:
+        _validate(url)
+    return url
+
+
+def get_requests_proxies() -> dict[str, str] | None:
+    """Return a requests-style {'http': url, 'https': url} dict, or None.
+
+    Used for requests calls and for the shodan/censys SDKs, which both
+    forward this dict to their internal requests.Session. SOCKS5 URLs work
+    transparently here as long as pysocks is installed.
+    """
+    url = get_proxy_url()
+    return {"http": url, "https": url} if url else None
+
+
+def get_aiohttp_proxy() -> str | None:
+    """Return the proxy URL for aiohttp's per-request proxy= kwarg (HTTP/HTTPS only).
+
+    aiohttp cannot use a SOCKS proxy via the plain proxy= kwarg — that case
+    is handled by get_aiohttp_connector() at session-creation time instead.
+    """
+    url = get_proxy_url()
+    if not url or _is_socks(url):
+        return None
+    return url
+
+
+def get_aiohttp_connector():
+    """Return an aiohttp_socks ProxyConnector when a SOCKS5 proxy is configured, else None."""
+    url = get_proxy_url()
+    if not url or not _is_socks(url):
+        return None
+    try:
+        from aiohttp_socks import ProxyConnector
+    except ImportError as exc:
+        raise ProxyConfigError(_SOCKS_INSTALL_HINT) from exc
+    return ProxyConnector.from_url(url)
+
+
+def get_subprocess_env() -> dict[str, str] | None:
+    """Return an env dict with proxy vars set for subprocess inheritance, or None.
+
+    None means "use the default" — run_subprocess() then omits env= entirely,
+    which preserves today's behavior of inheriting the parent environment.
+    """
+    url = get_proxy_url()
+    if not url:
+        return None
+    env = dict(os.environ)
+    env["HTTP_PROXY"] = url
+    env["HTTPS_PROXY"] = url
+    env["http_proxy"] = url
+    env["https_proxy"] = url
+    return env
+
+
+def get_sherlock_proxy_args() -> list[str]:
+    """Return ['--proxy', url] for sherlock's native flag, or [] when no proxy is set."""
+    url = get_proxy_url()
+    return ["--proxy", url] if url else []
+
+
+def redact_proxy_url(url: str | None) -> str:
+    """Mask user:pass in a proxy URL for safe logging: http://***:***@host:port."""
+    if not url:
+        return "none"
+    parts = urlsplit(url)
+    if not parts.username and not parts.password:
+        return url
+    netloc = f"***:***@{parts.hostname or ''}"
+    if parts.port:
+        netloc += f":{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def log_proxy_status(logger) -> None:
+    """Log one redacted line confirming proxy mode, if a proxy is configured."""
+    url = get_proxy_url()
+    if url:
+        logger.info("Upstream proxy active: %s", redact_proxy_url(url))

--- a/openosint/tools/search_abuseipdb.py
+++ b/openosint/tools/search_abuseipdb.py
@@ -16,6 +16,8 @@ import re
 
 import aiohttp
 
+from openosint.proxy import get_aiohttp_connector, get_aiohttp_proxy
+
 logger = logging.getLogger(__name__)
 
 _API_URL = "https://api.abuseipdb.com/api/v2/check"
@@ -56,8 +58,12 @@ async def _fetch_abuseipdb_data(ip: str, api_key: str, timeout: int) -> dict:
     headers = {"Key": api_key, "Accept": "application/json"}
     params = {"ipAddress": ip, "maxAgeInDays": str(_MAX_AGE_IN_DAYS)}
     timeout_cfg = aiohttp.ClientTimeout(total=timeout)
-    async with aiohttp.ClientSession(timeout=timeout_cfg) as session:
-        async with session.get(_API_URL, headers=headers, params=params) as resp:
+    async with aiohttp.ClientSession(
+        timeout=timeout_cfg, connector=get_aiohttp_connector()
+    ) as session:
+        async with session.get(
+            _API_URL, headers=headers, params=params, proxy=get_aiohttp_proxy()
+        ) as resp:
             _raise_for_status(resp.status)
             return await resp.json()
 

--- a/openosint/tools/search_breach.py
+++ b/openosint/tools/search_breach.py
@@ -15,6 +15,7 @@ import os
 
 import requests
 
+from openosint.proxy import get_requests_proxies
 from openosint.tools.exceptions import OSINTError, ToolExecutionError
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,7 @@ def _fetch_hibp_breaches(email: str, timeout_seconds: int, api_key: str) -> list
             headers=headers,
             params={"truncateResponse": "false"},
             timeout=timeout_seconds,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error querying HIBP: {exc}") from exc

--- a/openosint/tools/search_censys.py
+++ b/openosint/tools/search_censys.py
@@ -18,6 +18,7 @@ import logging
 import os
 import re
 
+from openosint.proxy import get_requests_proxies
 from openosint.tools.exceptions import OSINTError
 
 logger = logging.getLogger(__name__)
@@ -156,7 +157,7 @@ async def run_censys_osint(target: str, timeout_seconds: int = _DEFAULT_TIMEOUT,
 
     try:
         if _is_ip_address(target):
-            hosts = CensysHosts(api_id=api_id, api_secret=api_secret)
+            hosts = CensysHosts(api_id=api_id, api_secret=api_secret, proxies=get_requests_proxies())
             data = await asyncio.wait_for(
                 asyncio.to_thread(hosts.view, target),
                 timeout=float(timeout_seconds),
@@ -166,7 +167,7 @@ async def run_censys_osint(target: str, timeout_seconds: int = _DEFAULT_TIMEOUT,
             try:
                 from censys.search import CensysCerts  # type: ignore
 
-                certs = CensysCerts(api_id=api_id, api_secret=api_secret)
+                certs = CensysCerts(api_id=api_id, api_secret=api_secret, proxies=get_requests_proxies())
                 query = f"parsed.names: {target}"
                 search_results: list = await asyncio.wait_for(
                     asyncio.to_thread(
@@ -186,7 +187,7 @@ async def run_censys_osint(target: str, timeout_seconds: int = _DEFAULT_TIMEOUT,
                     timeout=float(timeout_seconds),
                 )
             except ImportError:
-                hosts = CensysHosts(api_id=api_id, api_secret=api_secret)
+                hosts = CensysHosts(api_id=api_id, api_secret=api_secret, proxies=get_requests_proxies())
                 search_results = await asyncio.wait_for(
                     asyncio.to_thread(
                         lambda: list(

--- a/openosint/tools/search_domain.py
+++ b/openosint/tools/search_domain.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 
+from openosint.proxy import get_subprocess_env
 from openosint.tools.exceptions import OSINTError
 from openosint.utils import run_subprocess
 
@@ -27,6 +28,7 @@ async def _run_sublist3r(domain: str, timeout_seconds: int) -> str:
         args=["-d", domain, "-n"],
         timeout_seconds=timeout_seconds,
         install_hint=_INSTALL_HINT,
+        env=get_subprocess_env(),
     )
     return result.stdout
 

--- a/openosint/tools/search_email.py
+++ b/openosint/tools/search_email.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 
+from openosint.proxy import get_subprocess_env
 from openosint.tools.exceptions import OSINTError, ToolExecutionError
 from openosint.utils import run_subprocess
 
@@ -27,6 +28,7 @@ async def _run_holehe(email: str, timeout_seconds: int) -> str:
         args=[email, "--only-used"],
         timeout_seconds=timeout_seconds,
         install_hint=_INSTALL_HINT,
+        env=get_subprocess_env(),
     )
     if result.return_code != 0:
         raise ToolExecutionError(f"holehe exited with code {result.return_code}: {result.stderr}")

--- a/openosint/tools/search_github.py
+++ b/openosint/tools/search_github.py
@@ -17,6 +17,8 @@ import os
 
 import aiohttp
 
+from openosint.proxy import get_aiohttp_connector, get_aiohttp_proxy
+
 logger = logging.getLogger(__name__)
 
 _API_BASE = "https://api.github.com"
@@ -41,7 +43,7 @@ async def _get(
     url: str,
     params: dict | None = None,
 ) -> dict | list | None:
-    async with session.get(url, params=params) as resp:
+    async with session.get(url, params=params, proxy=get_aiohttp_proxy()) as resp:
         if resp.status == 404:
             return None
         resp.raise_for_status()
@@ -138,6 +140,7 @@ async def run_github_osint(query: str, timeout_seconds: int = _DEFAULT_TIMEOUT, 
         async with aiohttp.ClientSession(
             headers=_build_headers(token),
             timeout=timeout_cfg,
+            connector=get_aiohttp_connector(),
         ) as session:
             user = await _fetch_user(session, query)
             if user:

--- a/openosint/tools/search_ip.py
+++ b/openosint/tools/search_ip.py
@@ -15,6 +15,7 @@ import os
 
 import requests
 
+from openosint.proxy import get_requests_proxies
 from openosint.tools.exceptions import OSINTError, ToolExecutionError
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ def _fetch_ip_data(ip: str, timeout_seconds: int, api_key: str | None = None) ->
             _IPINFO_URL.format(ip=ip),
             params=params,
             timeout=timeout_seconds,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error querying ipinfo.io: {exc}") from exc

--- a/openosint/tools/search_ip2location.py
+++ b/openosint/tools/search_ip2location.py
@@ -19,6 +19,7 @@ import re
 
 import requests
 
+from openosint.proxy import get_requests_proxies
 from openosint.tools.exceptions import OSINTError, ToolExecutionError
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,7 @@ def _fetch_ip2location_data(ip: str, api_key: str, timeout: int) -> dict:
             _API_URL,
             params={"key": api_key, "ip": ip, "format": "json"},
             timeout=timeout,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error querying IP2Location: {exc}") from exc

--- a/openosint/tools/search_paste.py
+++ b/openosint/tools/search_paste.py
@@ -13,6 +13,7 @@ import logging
 
 import requests
 
+from openosint.proxy import get_requests_proxies
 from openosint.tools.exceptions import OSINTError, ToolExecutionError
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ def _fetch_paste_data(query: str, timeout_seconds: int) -> list[dict]:
         response = requests.get(
             _PSBDMP_URL.format(query=query),
             timeout=timeout_seconds,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error querying psbdmp.ws: {exc}") from exc

--- a/openosint/tools/search_phone.py
+++ b/openosint/tools/search_phone.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 
+from openosint.proxy import get_subprocess_env
 from openosint.tools.exceptions import OSINTError, ToolExecutionError
 from openosint.utils import run_subprocess
 
@@ -27,6 +28,7 @@ async def _run_phoneinfoga(phone: str, timeout_seconds: int) -> str:
         args=["scan", "-n", phone],
         timeout_seconds=timeout_seconds,
         install_hint=_INSTALL_HINT,
+        env=get_subprocess_env(),
     )
     if not result.stdout:
         raise ToolExecutionError(

--- a/openosint/tools/search_shodan.py
+++ b/openosint/tools/search_shodan.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 
+from openosint.proxy import get_requests_proxies
 from openosint.tools.exceptions import OSINTError
 
 logger = logging.getLogger(__name__)
@@ -107,7 +108,7 @@ async def run_shodan_osint(query: str, timeout_seconds: int = _DEFAULT_TIMEOUT, 
 
     logger.info("Starting Shodan lookup for: %s", query)
     try:
-        api = shodan.Shodan(resolved_key)
+        api = shodan.Shodan(resolved_key, proxies=get_requests_proxies())
         if _is_ip_address(query):
             data = await asyncio.wait_for(
                 asyncio.to_thread(api.host, query),

--- a/openosint/tools/search_username.py
+++ b/openosint/tools/search_username.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 
+from openosint.proxy import get_sherlock_proxy_args
 from openosint.tools.exceptions import OSINTError
 from openosint.utils import run_subprocess
 
@@ -25,7 +26,7 @@ async def _run_sherlock(username: str, timeout_seconds: int) -> str:
     """Execute sherlock against username and return raw stdout."""
     result = await run_subprocess(
         binary=_BINARY,
-        args=[username, "--print-found", "--timeout", _PER_SITE_TIMEOUT],
+        args=[username, "--print-found", "--timeout", _PER_SITE_TIMEOUT, *get_sherlock_proxy_args()],
         timeout_seconds=timeout_seconds,
         install_hint=_INSTALL_HINT,
     )

--- a/openosint/tools/search_virustotal.py
+++ b/openosint/tools/search_virustotal.py
@@ -24,6 +24,7 @@ import re
 
 import requests
 
+from openosint.proxy import get_requests_proxies
 from openosint.tools.exceptions import OSINTError, ToolExecutionError
 
 logger = logging.getLogger(__name__)
@@ -179,6 +180,7 @@ def _lookup_ip(api_key: str, ip: str, timeout: int) -> str:
             f"{_BASE_URL}/ip_addresses/{ip}",
             headers=_headers(api_key),
             timeout=timeout,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error querying VirusTotal: {exc}") from exc
@@ -192,6 +194,7 @@ def _lookup_domain(api_key: str, domain: str, timeout: int) -> str:
             f"{_BASE_URL}/domains/{domain}",
             headers=_headers(api_key),
             timeout=timeout,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error querying VirusTotal: {exc}") from exc
@@ -208,6 +211,7 @@ async def _lookup_url(api_key: str, target_url: str, timeout: int) -> str:
             headers=_headers(api_key),
             data={"url": target_url},
             timeout=timeout,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error submitting URL to VirusTotal: {exc}") from exc
@@ -227,6 +231,7 @@ async def _lookup_url(api_key: str, target_url: str, timeout: int) -> str:
                 f"{_BASE_URL}/analyses/{analysis_id}",
                 headers=_headers(api_key),
                 timeout=timeout,
+                proxies=get_requests_proxies(),
             )
         except requests.RequestException as exc:
             raise OSINTError(f"Network error polling VirusTotal analysis: {exc}") from exc
@@ -245,6 +250,7 @@ def _lookup_hash(api_key: str, file_hash: str, timeout: int) -> str:
             f"{_BASE_URL}/files/{file_hash}",
             headers=_headers(api_key),
             timeout=timeout,
+            proxies=get_requests_proxies(),
         )
     except requests.RequestException as exc:
         raise OSINTError(f"Network error querying VirusTotal: {exc}") from exc

--- a/openosint/utils.py
+++ b/openosint/utils.py
@@ -35,6 +35,7 @@ async def run_subprocess(
     args: list[str],
     timeout_seconds: int,
     install_hint: str = "",
+    env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """
     Execute an external binary asynchronously and return its output.
@@ -49,6 +50,9 @@ async def run_subprocess(
         Hard wall-clock limit; process is killed on expiry.
     install_hint:
         Short installation message appended to ToolNotFoundError.
+    env:
+        Environment for the child process. None (default) inherits the
+        current process environment unchanged.
 
     Raises
     ------
@@ -74,6 +78,7 @@ async def run_subprocess(
             *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
         raw_stdout, raw_stderr = await asyncio.wait_for(
             process.communicate(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ pdf = [
 censys = [
     "censys>=2.2.0",
 ]
+socks = [
+    "PySocks>=1.7.1",
+    "aiohttp-socks>=0.8.4",
+]
 web = [
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.29.0",
@@ -101,6 +105,8 @@ all = [
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.29.0",
     "sse-starlette>=1.8.0",
+    "PySocks>=1.7.1",
+    "aiohttp-socks>=0.8.4",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,138 @@
+# tests/test_proxy.py
+"""
+Tests for openosint.proxy: precedence, redaction, and per-mechanism helpers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openosint import proxy
+
+
+@pytest.fixture(autouse=True)
+def _reset_proxy_state(monkeypatch):
+    """Ensure each test starts with no CLI flag and no env var set."""
+    proxy.set_cli_proxy_url(None)
+    monkeypatch.delenv(proxy._ENV_VAR, raising=False)
+    yield
+    proxy.set_cli_proxy_url(None)
+
+
+class TestPrecedence:
+    def test_returns_none_when_unset(self):
+        assert proxy.get_proxy_url() is None
+
+    def test_env_var_used_when_no_cli_flag(self, monkeypatch):
+        monkeypatch.setenv(proxy._ENV_VAR, "http://envhost:8080")
+        assert proxy.get_proxy_url() == "http://envhost:8080"
+
+    def test_cli_flag_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv(proxy._ENV_VAR, "http://envhost:8080")
+        proxy.set_cli_proxy_url("http://clihost:9090")
+        assert proxy.get_proxy_url() == "http://clihost:9090"
+
+
+class TestSchemeValidation:
+    def test_rejects_unsupported_scheme(self):
+        proxy.set_cli_proxy_url("ftp://host:21")
+        with pytest.raises(proxy.ProxyConfigError, match="Unsupported proxy scheme"):
+            proxy.get_proxy_url()
+
+    def test_accepts_http(self):
+        proxy.set_cli_proxy_url("http://host:8080")
+        assert proxy.get_proxy_url() == "http://host:8080"
+
+    def test_accepts_https(self):
+        proxy.set_cli_proxy_url("https://host:8443")
+        assert proxy.get_proxy_url() == "https://host:8443"
+
+
+class TestRequestsProxies:
+    def test_none_when_unset(self):
+        assert proxy.get_requests_proxies() is None
+
+    def test_dict_when_set(self):
+        proxy.set_cli_proxy_url("http://host:8080")
+        assert proxy.get_requests_proxies() == {
+            "http": "http://host:8080",
+            "https": "http://host:8080",
+        }
+
+
+class TestAiohttpProxy:
+    def test_none_when_unset(self):
+        assert proxy.get_aiohttp_proxy() is None
+
+    def test_returns_url_for_http(self):
+        proxy.set_cli_proxy_url("http://host:8080")
+        assert proxy.get_aiohttp_proxy() == "http://host:8080"
+
+    def test_none_for_socks_scheme(self, monkeypatch):
+        import sys
+        import types
+
+        monkeypatch.setitem(sys.modules, "socks", types.ModuleType("socks"))
+        proxy.set_cli_proxy_url("socks5://host:1080")
+        assert proxy.get_aiohttp_proxy() is None
+
+
+class TestSherlockArgs:
+    def test_empty_when_unset(self):
+        assert proxy.get_sherlock_proxy_args() == []
+
+    def test_flag_when_set(self):
+        proxy.set_cli_proxy_url("http://host:8080")
+        assert proxy.get_sherlock_proxy_args() == ["--proxy", "http://host:8080"]
+
+
+class TestSubprocessEnv:
+    def test_none_when_unset(self):
+        assert proxy.get_subprocess_env() is None
+
+    def test_sets_proxy_vars_when_configured(self):
+        proxy.set_cli_proxy_url("http://host:8080")
+        env = proxy.get_subprocess_env()
+        assert env["HTTP_PROXY"] == "http://host:8080"
+        assert env["HTTPS_PROXY"] == "http://host:8080"
+        assert env["http_proxy"] == "http://host:8080"
+        assert env["https_proxy"] == "http://host:8080"
+
+    def test_preserves_existing_environment(self, monkeypatch):
+        monkeypatch.setenv("SOME_UNRELATED_VAR", "keep-me")
+        proxy.set_cli_proxy_url("http://host:8080")
+        env = proxy.get_subprocess_env()
+        assert env["SOME_UNRELATED_VAR"] == "keep-me"
+
+
+class TestRedaction:
+    def test_none_url_returns_none_literal(self):
+        assert proxy.redact_proxy_url(None) == "none"
+
+    def test_masks_username_and_password(self):
+        redacted = proxy.redact_proxy_url("http://myuser:mypassword@proxy.example.com:8080")
+        assert "myuser" not in redacted
+        assert "mypassword" not in redacted
+        assert redacted == "http://***:***@proxy.example.com:8080"
+
+    def test_no_credentials_returns_url_unchanged(self):
+        assert proxy.redact_proxy_url("http://proxy.example.com:8080") == (
+            "http://proxy.example.com:8080"
+        )
+
+
+class TestSocksExtraMissing:
+    def test_clear_error_when_pysocks_missing(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "socks":
+                raise ImportError("no module named socks")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        proxy.set_cli_proxy_url("socks5://host:1080")
+        with pytest.raises(proxy.ProxyConfigError, match="pip install openosint\\[socks\\]"):
+            proxy.get_proxy_url()


### PR DESCRIPTION
Adds openosint/proxy.py: a single source of truth for an upstream proxy (--proxy flag or OPENOSINT_PROXY_URL env var), with helpers for requests, aiohttp, subprocess-based tools (sherlock), and redacted logging. Wires it into the 12 web-facing search tools, cli.py, and utils.py. Excludes search_dns, generate_dorks, and the Bright Data / Anthropic-backed tools by design (see proxy.py module docstring).

## Summary

<!-- What does this PR do? One to three sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New integration (new OSINT tool or external API)
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Other (describe below)

## Test plan

<!-- Steps to verify this change works correctly. -->

## Checklist

- [ ] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, and `CLAUDE.md`
- [ ] README and docs updated where applicable
- [ ] If adding an integration: the new tool is registered in `agent.py`, `mcp_server.py`, `cli.py`, `repl.py`, and `web_server.py`
- [ ] `.env.example` updated for any new environment variable
- [ ] No secrets or API keys committed
