### PR TITLE
Add free-prompts CTAs to README and report footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ openosint web
 openosint email target@example.com
 ```
 
+New to OSINT methodology? Grab the [free 5-prompt starter set](https://openosint.tech/free-prompts?utm_source=github&utm_medium=readme-quickstart&utm_campaign=free_prompts) before your first run.
+
 ## Usage
 
 Start the REPL and investigate any target — the agent decides which tools to run and chains them on findings:
@@ -624,9 +626,9 @@ New to AI-assisted OSINT? The **free starter set** gives you 5 structured prompt
 
 - Scope → Collect → Pivot → Verify → Document
 - Works with any AI assistant (Claude, ChatGPT, Gemini)
-- Free PDF, instant download — enter $0, no card needed
+- Free PDF, instant download — just your email
 
-**→ [Free download on Gumroad](https://tommasodev.gumroad.com/l/free-osint-prompts?utm_source=github&utm_medium=readme&utm_campaign=free_starter)**
+**→ [Get the free starter set](https://openosint.tech/free-prompts?utm_source=github&utm_medium=readme-resources&utm_campaign=free_prompts)**
 
 ### AI OSINT Prompt Pack
 
@@ -635,6 +637,8 @@ OpenOSINT gives you the tooling. The **AI OSINT Prompt Pack** gives you the meth
 - Email, username, domain, IP, phone, company due-diligence, image & reporting prompts
 - One repeatable investigation flow + an ethics & legal primer
 - 7-page PDF · instant download · pairs directly with OpenOSINT
+
+Not ready to buy? Start with the [free 5-prompt starter set](https://openosint.tech/free-prompts?utm_source=github&utm_medium=readme-promptpack&utm_campaign=free_prompts).
 
 **→ [Get the Prompt Pack ($29)](https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=github&utm_medium=readme&utm_campaign=prompt_pack)**
 

--- a/docs/free-prompts/index.html
+++ b/docs/free-prompts/index.html
@@ -179,7 +179,7 @@ Return findings as &#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x25
 <h2 id="get">GET THE FREE PROMPTS</h2>
 <div class="indent">
 <p>Enter $0 on Gumroad. No card, no account required. The PDF downloads immediately.</p>
-<a class="fp-cta-btn" href="https://tommasodev.gumroad.com/l/free-osint-prompts?wanted=true&amp;utm_source=site&amp;utm_medium=free_prompts_page&amp;utm_campaign=free_starter" target="_blank" rel="noopener">Download free PDF &rarr;</a>
+<a class="fp-cta-btn fp-gumroad-link" href="https://tommasodev.gumroad.com/l/free-osint-prompts?wanted=true&amp;utm_source=site&amp;utm_medium=free_prompts_page&amp;utm_campaign=free_starter" target="_blank" rel="noopener">Download free PDF &rarr;</a>
 <p style="margin-top:14px;font-size:12px;color:#666;">From the maker of OpenOSINT, an open-source OSINT framework used by security researchers and analysts worldwide. No spam &mdash; unsubscribe anytime.</p>
 </div>
 
@@ -188,7 +188,7 @@ Return findings as &#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x25
 <h2 id="full-pack">FULL PACK</h2>
 <div class="indent">
 <p>The free set walks the investigation loop once. The <b>AI OSINT Prompt Pack</b> has 30+ prompts covering every investigation type: email, username, domain, IP, phone, company due diligence, image analysis, verification patterns, and final reporting &mdash; plus the complete methodology and an ethics and legal primer.</p>
-<p><a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=free_prompts_page&amp;utm_campaign=prompt_pack" target="_blank" rel="noopener" style="font-weight:bold;color:#9fb0c3;">Buy the full pack ($29) &#8599;</a></p>
+<p><a class="fp-gumroad-link" href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=free_prompts_page&amp;utm_campaign=prompt_pack" target="_blank" rel="noopener" style="font-weight:bold;color:#9fb0c3;">Buy the full pack ($29) &#8599;</a></p>
 </div>
 
 <hr>
@@ -211,5 +211,28 @@ Return findings as &#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x25
 </div>
 
 </div>
+
+<script>
+(function () {
+  // ponytail: forwards the incoming referrer's UTM params onto the outbound
+  // Gumroad links so per-placement conversion survives the /free-prompts hop
+  // instead of collapsing into the hardcoded utm_medium=free_prompts_page.
+  var qs = new URLSearchParams(window.location.search);
+  var overrides = {};
+  ['utm_source', 'utm_medium', 'utm_campaign'].forEach(function (key) {
+    var value = qs.get(key);
+    if (value) overrides[key] = value;
+  });
+  if (!Object.keys(overrides).length) return;
+
+  document.querySelectorAll('a.fp-gumroad-link').forEach(function (link) {
+    var url = new URL(link.href);
+    Object.keys(overrides).forEach(function (key) {
+      url.searchParams.set(key, overrides[key]);
+    });
+    link.href = url.toString();
+  });
+})();
+</script>
 </body>
 </html>

--- a/openosint/repl.py
+++ b/openosint/repl.py
@@ -249,12 +249,19 @@ def _print_config(
 # ---------------------------------------------------------------------------
 
 
+_REPORT_FOOTER = (
+    "\n\n---\n"
+    "*Free 5-prompt OSINT starter set: "
+    "https://openosint.tech/free-prompts?utm_source=cli&utm_medium=report-footer&utm_campaign=free_prompts*\n"
+)
+
+
 def _save_report(content: str) -> Path:
     reports_dir = Path("reports")
     reports_dir.mkdir(exist_ok=True)
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     path = reports_dir / f"{timestamp}_report.md"
-    path.write_text(content, encoding="utf-8")
+    path.write_text(content + _REPORT_FOOTER, encoding="utf-8")
     return path
 
 


### PR DESCRIPTION
## Summary
- README.md: adds free 5-prompt starter set CTAs to Quick Start, Resources > Free Starter Set (repointed from a Gumroad $0-checkout link to openosint.tech/free-prompts), and the AI OSINT Prompt Pack section — each with a distinct `utm_medium` (readme-quickstart / readme-resources / readme-promptpack) so per-placement conversion is trackable.
- Saved investigation reports (Markdown, and PDF via the existing md→pdf conversion) get a one-line footer pointing to the same page (`utm_medium=report-footer`).
- docs/free-prompts/index.html: forwards any incoming `utm_source`/`utm_medium`/`utm_campaign` onto the page's two outbound Gumroad links, which otherwise hardcode `utm_medium=free_prompts_page` and would erase whichever README/report placement sent the visitor there.

## Context
Kit analytics previously showed very little README traffic reaching the lead magnet. Root cause: README.md (on this branch's stale base) had no link to the free capture page at all, only to a paid Polar checkout that's since been confirmed dead (Polar account closed). This PR is scoped to the free-prompts funnel only — a separate PR will handle replacing the dead Polar links repo-wide.

## Test plan
- [x] `pytest tests/ -k "repl or report or sponsor"` — 40 passed
- [ ] Manual: load `/free-prompts/?utm_source=github&utm_medium=readme-quickstart&utm_campaign=free_prompts` and confirm both Gumroad CTA links pick up those params
- [ ] Manual: run `openosint` REPL, generate a report, confirm the footer line appears in the saved `.md` and generated `.pdf`