### PR TITLE
feat(site): add contextual Gumroad CTAs across high-intent docs pages

### DIFF
--- a/docs/blog/ai-hallucination-osint.html
+++ b/docs/blog/ai-hallucination-osint.html
@@ -116,11 +116,11 @@ result = await run_ip_osint("8.8.8.8")  # hits ipinfo.io API
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/breach-check-open-source.html
+++ b/docs/blog/breach-check-open-source.html
@@ -150,11 +150,11 @@ else:
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/claude-code-osint.html
+++ b/docs/blog/claude-code-osint.html
@@ -146,11 +146,11 @@ async def bulk_whois(domains: list[str]) -> list[dict]:
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/email-osint-guide.html
+++ b/docs/blog/email-osint-guide.html
@@ -150,11 +150,11 @@
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/google-dorks-guide.html
+++ b/docs/blog/google-dorks-guide.html
@@ -132,11 +132,11 @@ site:target.com intext:"@target.com" filetype:pdf
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/ip-intelligence-guide.html
+++ b/docs/blog/ip-intelligence-guide.html
@@ -171,11 +171,11 @@ $ openosint ip2location 198.51.100.1
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/ip-reputation-osint.html
+++ b/docs/blog/ip-reputation-osint.html
@@ -156,11 +156,11 @@
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/mcp-protocol-explained.html
+++ b/docs/blog/mcp-protocol-explained.html
@@ -170,11 +170,11 @@ Response (server → client):
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/ollama-osint.html
+++ b/docs/blog/ollama-osint.html
@@ -131,11 +131,11 @@ openosint [ollama/qwen2.5:14b] &gt; investigate 8.8.8.8
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/osint-ai-agents.html
+++ b/docs/blog/osint-ai-agents.html
@@ -126,11 +126,11 @@
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/osint-api-automation.html
+++ b/docs/blog/osint-api-automation.html
@@ -155,11 +155,11 @@ async def bulk_ip_check(ips: list[str], key: str) -> dict:
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/osint-cli-tools.html
+++ b/docs/blog/osint-cli-tools.html
@@ -119,11 +119,11 @@ openosint &gt; investigate target@example.com</pre>
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/osint-for-bug-bounty.html
+++ b/docs/blog/osint-for-bug-bounty.html
@@ -116,11 +116,11 @@
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/osint-report-generation.html
+++ b/docs/blog/osint-report-generation.html
@@ -150,11 +150,11 @@ git add reports/ &amp;&amp; git commit -m "Weekly OSINT run ${DATE}"</pre>
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/osint-with-mcp.html
+++ b/docs/blog/osint-with-mcp.html
@@ -144,11 +144,11 @@ claude mcp list</pre>
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/parallel-osint.html
+++ b/docs/blog/parallel-osint.html
@@ -148,11 +148,11 @@ for asn, targets in asn_groups.items():
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/pastebin-osint.html
+++ b/docs/blog/pastebin-osint.html
@@ -149,11 +149,11 @@ $ openosint
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/phone-number-osint.html
+++ b/docs/blog/phone-number-osint.html
@@ -150,11 +150,11 @@ Phone intelligence for '+14155552671':
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/subdomain-enumeration.html
+++ b/docs/blog/subdomain-enumeration.html
@@ -156,11 +156,11 @@ openosint domain target.com
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/username-search-300-platforms.html
+++ b/docs/blog/username-search-300-platforms.html
@@ -137,11 +137,11 @@
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/what-is-osint.html
+++ b/docs/blog/what-is-osint.html
@@ -129,11 +129,11 @@
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/blog/whois-lookup-automation.html
+++ b/docs/blog/whois-lookup-automation.html
@@ -176,11 +176,11 @@ for domain in domains:
 </div>
 
 
-<aside style="border:1px solid #1f2a44;background:#0b1220;border-radius:12px;padding:20px;margin:32px 0;">
-  <strong style="color:#e6edf3;font-size:1.05rem;">Free: 5 AI OSINT prompts that actually work</strong>
-  <p style="color:#9fb0c3;margin:8px 0 14px;">ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
-  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
-  <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
+<aside class="oo-cta">
+  <strong>Free: 5 AI OSINT prompts that actually work</strong>
+  <p>ChatGPT hallucinates when you give it a vague task. These 5 structured prompts force it to collect at every stage: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document. Free PDF &mdash; no card, instant download.</p>
+  <a href="/free-prompts/?utm_source=site&amp;utm_medium=article_cta&amp;utm_campaign=free_starter" class="oo-cta-btn">Download free PDF &rarr;</a>
+  <p class="oo-cta-sub">Want 30+ prompts like this one, ready to use? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=article_footer&amp;utm_campaign=prompt_pack_discount">Get the pack &mdash; $14.50 today &#8599;</a></p>
 </aside>
 <hr>
 

--- a/docs/free-prompts/index.html
+++ b/docs/free-prompts/index.html
@@ -188,7 +188,7 @@ Return findings as &#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x25
 <h2 id="full-pack">FULL PACK</h2>
 <div class="indent">
 <p>The free set walks the investigation loop once. The <b>AI OSINT Prompt Pack</b> has 30+ prompts covering every investigation type: email, username, domain, IP, phone, company due diligence, image analysis, verification patterns, and final reporting &mdash; plus the complete methodology and an ethics and legal primer.</p>
-<p><a class="fp-gumroad-link" href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=free_prompts_page&amp;utm_campaign=prompt_pack" target="_blank" rel="noopener" style="font-weight:bold;color:#9fb0c3;">Buy the full pack ($29) &#8599;</a></p>
+<p><a class="fp-gumroad-link oo-cta-btn" href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=free_prompts_page&amp;utm_campaign=prompt_pack_discount" target="_blank" rel="noopener">Get the pack &mdash; $14.50 today &rarr;</a></p>
 </div>
 
 <hr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -134,6 +134,27 @@ openosint [<b>-v</b>] [<b>--api-key</b> <u>key</u>]</pre>
   <a href="/free-prompts/?utm_source=site&amp;utm_medium=hero&amp;utm_campaign=free_starter" style="display:inline-block;background:#3fb950;color:#000;padding:10px 20px;border-radius:4px;text-decoration:none;font-weight:bold;font-family:monospace;font-size:14px;">Download free PDF &rarr;</a>
   <p style="margin:12px 0 0;font-size:0.82rem;color:#556270;">Want 30+ prompts? <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=hero&amp;utm_campaign=prompt_pack" style="color:#9fb0c3;">Full pack ($29) &#8599;</a></p>
 </aside>
+
+<div class="oo-cta-compare">
+  <div>
+    <h4>Free Starter Set</h4>
+    <div class="price">$0</div>
+    <p>5 structured prompts, one per investigation stage. Instant PDF, no card.</p>
+    <a href="/free-prompts/?utm_source=site&amp;utm_medium=compare&amp;utm_campaign=free_starter" class="oo-cta-btn oo-cta-btn--ghost">Download free &rarr;</a>
+  </div>
+  <div>
+    <h4>AI OSINT Prompt Pack</h4>
+    <div class="price">$29</div>
+    <p>30+ prompts: email, username, domain, IP, phone, company due diligence, image analysis, verification, reporting.</p>
+    <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=compare&amp;utm_campaign=prompt_pack" class="oo-cta-btn">Get the pack &rarr;</a>
+  </div>
+  <div class="featured">
+    <h4>Complete Kit <span style="color:#3fb950;font-size:0.75em;">(best value)</span></h4>
+    <div class="price">$55</div>
+    <p>Prompt Pack + the AI OSINT Operator's Playbook &mdash; full methodology and step-by-step workflows.</p>
+    <a href="https://tommasodev.gumroad.com/l/ai-osint-complete-kit?utm_source=site&amp;utm_medium=compare&amp;utm_campaign=complete_kit" class="oo-cta-btn">Get the kit &rarr;</a>
+  </div>
+</div>
 </div>
 
 <h2 id="commercial">FOR TEAMS &amp; ORGANIZATIONS</h2>

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -93,11 +93,26 @@
 
 <h2 id="deeper">GO DEEPER</h2>
 <div class="indent">
-<ul>
-  <li><b><a href="/free-prompts/?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=free_starter">Free AI OSINT Prompt Starter Set</a></b> &mdash; 5 structured prompts that make ChatGPT and Claude collect real data instead of hallucinating. Free PDF, instant download, no card needed.</li>
-  <li><b><a href="https://tommasodev.gumroad.com/l/ai-osint-complete-kit?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=complete_kit" target="_blank" rel="noopener">AI OSINT Complete Kit (Playbook + Prompt Pack)</a></b> &mdash; practical guide to running AI-assisted OSINT investigations, with 30+ ready-to-use prompts and the full methodology.</li>
-  <li><b><a href="https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=operator_playbook" target="_blank" rel="noopener">AI OSINT Operator's Playbook</a></b> &mdash; paid guide ($39) with step-by-step workflows for running investigations with ChatGPT, Claude, and OpenOSINT.</li>
-</ul>
+<div class="oo-cta-compare">
+  <div>
+    <h4>Free Starter Set</h4>
+    <div class="price">$0</div>
+    <p>5 structured prompts that make ChatGPT and Claude collect real data instead of hallucinating. Instant PDF, no card needed.</p>
+    <a href="/free-prompts/?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=free_starter" class="oo-cta-btn oo-cta-btn--ghost">Download free &rarr;</a>
+  </div>
+  <div>
+    <h4>Operator's Playbook</h4>
+    <div class="price">$39</div>
+    <p>Step-by-step workflows for running investigations with ChatGPT, Claude, and OpenOSINT.</p>
+    <a href="https://tommasodev.gumroad.com/l/ai-osint-playbook?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=operator_playbook" target="_blank" rel="noopener" class="oo-cta-btn">Get the Playbook &rarr;</a>
+  </div>
+  <div class="featured">
+    <h4>Complete Kit <span style="color:#3fb950;font-size:0.75em;">(best value)</span></h4>
+    <div class="price">$55</div>
+    <p>Playbook + 30+ ready-to-use prompts &mdash; the full methodology.</p>
+    <a href="https://tommasodev.gumroad.com/l/ai-osint-complete-kit?utm_source=site&amp;utm_medium=learn&amp;utm_campaign=complete_kit" target="_blank" rel="noopener" class="oo-cta-btn">Get the kit &rarr;</a>
+  </div>
+</div>
 </div>
 
 <hr>

--- a/docs/prompt-pack.html
+++ b/docs/prompt-pack.html
@@ -28,7 +28,7 @@
     "@type": "Offer",
     "priceCurrency": "USD",
     "availability": "https://schema.org/InStock",
-    "url": "https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?ref=site-page"
+    "url": "https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&utm_medium=product_page&utm_campaign=prompt_pack"
   },
   "publisher": { "@type": "Organization", "name": "OpenOSINT", "url": "https://openosint.tech" }
 }
@@ -155,7 +155,20 @@ Document: breach history, account surface, confidence level,
 
 <h2 id="get">GET THE PACK</h2>
 <div class="indent">
-<p><a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?ref=site-page" target="_blank" rel="noopener"><b>Download from Gumroad &rarr;</b></a></p>
+<p><a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=product_page&amp;utm_campaign=prompt_pack" target="_blank" rel="noopener"><b>Download from Gumroad &rarr;</b></a></p>
+
+<div class="oo-cta-row">
+  <div class="oo-cta">
+    <strong>On the fence?</strong>
+    <p>Take $14.50 off the Prompt Pack — same 30+ prompts, discount applied automatically at checkout.</p>
+    <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=product_page_footer&amp;utm_campaign=prompt_pack_discount" class="oo-cta-btn">Get it for $14.50 &rarr;</a>
+  </div>
+  <div class="oo-cta">
+    <strong>Want the full methodology too?</strong>
+    <p>The Complete Kit bundles this pack with the AI OSINT Operator's Playbook for $55.</p>
+    <a href="https://tommasodev.gumroad.com/l/ai-osint-complete-kit?utm_source=site&amp;utm_medium=product_page_footer&amp;utm_campaign=complete_kit" class="oo-cta-btn oo-cta-btn--ghost">See the Complete Kit &rarr;</a>
+  </div>
+</div>
 </div>
 
 <h2 id="see-also">SEE ALSO</h2>

--- a/docs/style.css
+++ b/docs/style.css
@@ -197,6 +197,110 @@ a:visited {
 }
 
 /* ------------------------------------------------------------------ */
+/* CTA component — free/paid conversion blocks (blog, tools, product)  */
+/* ------------------------------------------------------------------ */
+
+.oo-cta {
+  border: 1px solid #1f2a44;
+  background: #0b1220;
+  border-radius: 12px;
+  padding: 20px;
+  margin: 32px 0;
+}
+
+.oo-cta strong {
+  color: #e6edf3;
+  font-size: 1.05rem;
+}
+
+.oo-cta p {
+  color: #9fb0c3;
+  margin: 8px 0 14px;
+  text-align: left;
+  font-size: 0.92rem;
+}
+
+.oo-cta-btn {
+  display: inline-block;
+  background: #3fb950;
+  color: #000000 !important;
+  padding: 10px 20px;
+  border-radius: 4px;
+  text-decoration: none !important;
+  font-weight: bold;
+  font-family: monospace;
+  font-size: 14px;
+}
+
+.oo-cta-btn:hover { background: #2ea043; }
+
+.oo-cta-btn--ghost {
+  background: transparent;
+  border: 1px solid #3fb950;
+  color: #3fb950 !important;
+}
+
+.oo-cta-btn--ghost:hover { background: #3fb950; color: #000000 !important; }
+
+.oo-cta-sub {
+  margin: 12px 0 0 !important;
+  font-size: 0.82rem;
+  color: #556270;
+}
+
+.oo-cta-sub a { color: #9fb0c3; }
+
+.oo-cta-row {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.oo-cta-row .oo-cta { flex: 1; min-width: 240px; margin: 0; }
+
+.oo-cta-compare {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin: 20px 0;
+}
+
+.oo-cta-compare > div {
+  flex: 1;
+  min-width: 190px;
+  border: 1px solid #1f2a44;
+  background: #0b1220;
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+
+.oo-cta-compare > div.featured { border-color: #3fb950; }
+
+.oo-cta-compare h4 {
+  color: #e6edf3;
+  font-family: monospace;
+  font-size: 0.92rem;
+  margin-bottom: 4px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.oo-cta-compare .price {
+  color: #3fb950;
+  font-size: 1.3rem;
+  font-weight: bold;
+  margin: 6px 0;
+}
+
+.oo-cta-compare p {
+  color: #9fb0c3;
+  font-size: 0.8rem;
+  text-align: left;
+  margin: 8px 0 10px;
+}
+
+/* ------------------------------------------------------------------ */
 /* Dark mode — terminal users                                           */
 /* ------------------------------------------------------------------ */
 

--- a/docs/tools/index.html
+++ b/docs/tools/index.html
@@ -36,6 +36,12 @@
 <h2>TOOLS REFERENCE</h2>
 <div class="indent">
 <p>OpenOSINT exposes 14 intelligence-gathering modules. Each tool is an async Python wrapper around an external binary or API. All tools are available via the <a href="/">interactive REPL</a>, the CLI, and the <a href="/#mcp">MCP server</a>.</p>
+
+<aside class="oo-cta">
+  <strong>Running these tools by hand? The prompts decide what to ask them.</strong>
+  <p>OpenOSINT runs the lookups — the AI OSINT Prompt Pack has 30+ ready-to-use prompts that chain these exact tools into a full investigation: scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document.</p>
+  <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=tools_contextual&amp;utm_campaign=prompt_pack" class="oo-cta-btn">Get the Prompt Pack ($29) &rarr;</a>
+</aside>
 </div>
 
 <h2>QUICK REFERENCE</h2>
@@ -220,6 +226,19 @@
 </div>
 
 <hr>
+
+<div class="oo-cta-row" style="margin:24px 0;">
+  <div class="oo-cta">
+    <strong>Just need the tools?</strong>
+    <p>All 14 modules above are free and MIT-licensed. Grab the 5-prompt starter set to see the scope &rarr; collect &rarr; pivot &rarr; verify &rarr; document method in action.</p>
+    <a href="/free-prompts/?utm_source=site&amp;utm_medium=tools_footer&amp;utm_campaign=free_starter" class="oo-cta-btn oo-cta-btn--ghost">Download free PDF &rarr;</a>
+  </div>
+  <div class="oo-cta">
+    <strong>Want the full prompt library?</strong>
+    <p>30+ prompts covering every tool above, plus company due diligence, image analysis, and reporting formats.</p>
+    <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack/LOOP50?utm_source=site&amp;utm_medium=tools_footer&amp;utm_campaign=prompt_pack_discount" class="oo-cta-btn">Get the pack &mdash; $14.50 today &rarr;</a>
+  </div>
+</div>
 
 <div style="margin-top:24px; padding-top:12px; border-top:1px solid #ccc; font-family:monospace; font-size:12px; text-align:center;">
 <a href="/">Home</a> &middot;


### PR DESCRIPTION
Adds a reusable CTA component (.oo-cta / .oo-cta-btn / .oo-cta-row / .oo-cta-compare in docs/style.css) and wires it into every high-intent page that previously funneled visitors only to the free prompt set:

- docs/tools/index.html: was the highest-intent page with zero Gumroad path; adds a contextual Prompt Pack CTA plus a free/paid footer block
- docs/index.html: adds a 3-column Free/Prompt Pack/Complete Kit comparison next to the existing free hero
- docs/prompt-pack.html: UTM-tags the previously bare product link, adds a Complete Kit cross-sell
- docs/learn/index.html: restyles existing Playbook/Complete Kit links into the comparison component (same destinations, same UTMs)
- 22 blog articles: upgrades the identical free-only CTA aside into a free+paid footer block with sharper, outcome-specific copy
- docs/free-prompts/index.html: converts the paid cross-sell to the LOOP50 discount link

LOOP50 is used only in footer-dual blocks where Prompt Pack is the featured product; Complete Kit and Playbook stay full price everywhere. UTM tagging extends the site's existing utm_source=site convention with a distinct utm_medium/utm_campaign per new placement, preserving continuity with prior Gumroad analytics instead of introducing a new scheme.

## Summary

<!-- What does this PR do? One to three sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New integration (new OSINT tool or external API)
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Other (describe below)

## Test plan

<!-- Steps to verify this change works correctly. -->

## Checklist

- [ ] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, and `CLAUDE.md`
- [ ] README and docs updated where applicable
- [ ] If adding an integration: the new tool is registered in `agent.py`, `mcp_server.py`, `cli.py`, `repl.py`, and `web_server.py`
- [ ] `.env.example` updated for any new environment variable
- [ ] No secrets or API keys committed
