### PR TITLE
Funnel: reposition CTAs, remove MCP-integration copy, replace bespoke masthead with Gumroad product block

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ openosint > investigate target@example.com
 ## Custom Integrations
 
 Need OpenOSINT wired into your SOC, fraud, threat-intel, or AI-agent stack?
-I build bespoke OSINT & MCP integrations for teams — you bring the data
+I build bespoke OSINT integrations for teams — you bring the data
 sources and compliance requirements, I deliver a working integration.
 
 → **[Get in touch](mailto:commercial@openosint.tech?subject=OpenOSINT%20Custom%20Integration)**

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>OpenOSINT Blog — OSINT Guides, Tutorials &amp; Research</title>
-<meta name="description" content="Tutorials, guides, and research on OSINT investigations using OpenOSINT. Topics: email enumeration, IP analysis, MCP integration, AI-powered intelligence gathering.">
+<meta name="description" content="Tutorials, guides, and research on OSINT investigations using OpenOSINT. Topics: email enumeration, IP analysis, AI agent tooling, AI-powered intelligence gathering.">
 <meta name="keywords" content="OSINT blog, open source intelligence tutorials, OSINT tools guide, AI OSINT, MCP server OSINT, email investigation">
 <link rel="canonical" href="https://openosint.tech/blog/">
 <meta property="og:title" content="OpenOSINT Blog — OSINT Guides, Tutorials &amp; Research">
@@ -62,7 +62,7 @@
 <p>
   <b><a href="/blog/mcp-protocol-explained.html">Model Context Protocol Explained: How AI Agents Use External Tools</a></b><br>
   <span style="font-family:monospace;font-size:12px;">2026-05-24 &mdash; 5 min read</span><br>
-  JSON-RPC over stdio, host/client/server architecture, and why MCP is the right transport for OSINT tool integration.
+  JSON-RPC over stdio, host/client/server architecture, and how OpenOSINT exposes its tools to AI clients.
 </p>
 
 <hr>

--- a/docs/blog/ip-reputation-osint.html
+++ b/docs/blog/ip-reputation-osint.html
@@ -149,7 +149,7 @@
 <div class="indent">
 <ul>
 <li><a href="/tools/">Full tools reference</a> &mdash; parameters, output format, and all 14 tools</li>
-<li><a href="/blog/osint-with-mcp.html">MCP integration guide</a> &mdash; run these tools from Claude Desktop automatically</li>
+<li><a href="/blog/osint-with-mcp.html">Claude Desktop setup guide</a> &mdash; run these tools from Claude Desktop automatically</li>
 <li><a href="/">OpenOSINT documentation</a> &mdash; complete manual</li>
 <li><a href="/cloud/">OpenOSINT Cloud</a> &mdash; Hosted IP abuse reputation and infrastructure intelligence API. Includes AbuseIPDB, IP2Location, and DNS — no API keys to manage.</li>
 </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,11 +95,28 @@
 
 <hr>
 
-<div style="background:#fffdf0;border:1px solid #ddd;border-left:2px solid #bbb;padding:14px 18px;margin:16px 0;font-family:monospace;font-size:13px;">
-<p style="margin:0 0 6px 0;"><b>Custom OSINT &amp; MCP Integrations</b> &mdash; Bespoke OSINT &amp; MCP integrations wired into your SOC, fraud, threat-intel, or AI-agent stack. You bring the data sources and compliance requirements; I deliver a working, maintainable integration.</p>
-<p style="margin:0 0 8px 0;color:#444;">Maintainer of OpenOSINT (<span data-metric="stars">1,017</span> stars) &middot; MCP-native</p>
-<p style="margin:0;"><a href="mailto:commercial@openosint.tech?subject=OpenOSINT%20Custom%20Integration" style="color:#3fb950;font-weight:bold;">Get in touch &rarr;</a></p>
-</div>
+<aside class="oo-cta" style="text-align:center;">
+  <p style="color:#9fb0c3;margin:0 0 12px;">Maintainer of OpenOSINT (<span data-metric="stars">1,017</span> stars)</p>
+  <div class="oo-cta-compare">
+    <div>
+      <h4>Start Free</h4>
+      <p>5 prompts, no card, instant PDF.</p>
+      <a href="/free-prompts/?utm_source=site&amp;utm_medium=top_hero&amp;utm_campaign=free_starter" class="oo-cta-btn oo-cta-btn--ghost">Start free &rarr;</a>
+    </div>
+    <div>
+      <h4>Prompt Pack</h4>
+      <div class="price">$29</div>
+      <p>30+ ready-to-use prompts.</p>
+      <a href="https://tommasodev.gumroad.com/l/ai-osint-prompt-pack?utm_source=site&amp;utm_medium=top_hero&amp;utm_campaign=prompt_pack" class="oo-cta-btn">Get the pack &rarr;</a>
+    </div>
+    <div class="featured">
+      <h4>Complete Kit <span style="color:#3fb950;font-size:0.75em;">(best value)</span></h4>
+      <div class="price">$55</div>
+      <p>Prompt Pack + Operator's Playbook.</p>
+      <a href="https://tommasodev.gumroad.com/l/ai-osint-complete-kit?utm_source=site&amp;utm_medium=top_hero&amp;utm_campaign=complete_kit" class="oo-cta-btn">Get the kit &rarr;</a>
+    </div>
+  </div>
+</aside>
 
 <h2 id="name">NAME</h2>
 <div class="indent">
@@ -155,6 +172,35 @@ openosint [<b>-v</b>] [<b>--api-key</b> <u>key</u>]</pre>
     <a href="https://tommasodev.gumroad.com/l/ai-osint-complete-kit?utm_source=site&amp;utm_medium=compare&amp;utm_campaign=complete_kit" class="oo-cta-btn">Get the kit &rarr;</a>
   </div>
 </div>
+</div>
+
+<h2 id="services">SERVICES</h2>
+<div class="indent">
+<p>OpenOSINT is free and MIT-licensed. The following is an optional paid setup service offered by the maintainer.</p>
+<p><b>OSINT-MCP Setup Sprint</b> &mdash; done-for-you installation and configuration of an autonomous OSINT-MCP pipeline on your environment. Fully async, no calls required.</p>
+<p><b>Includes:</b></p>
+<ul>
+<li>Pre-configured OpenOSINT setup tailored to your stack (Claude Code, Claude Desktop, or any MCP client)</li>
+<li>API keys wired in &mdash; Shodan, VirusTotal, IP2Location, HaveIBeenPwned, and others as needed</li>
+<li>One investigation workflow built around your use case</li>
+<li>Written step-by-step setup guide + screen-recorded walkthrough</li>
+<li>1-page runbook</li>
+<li>Async email support for 7 days</li>
+</ul>
+<p><b>Delivery:</b> 3&ndash;5 days, fully async.</p>
+<p><b>For:</b> SOC analysts &middot; threat-intel teams &middot; fraud/AML &middot; pentesters &middot; OSINT investigators</p>
+<p><b>Founding pricing</b> available for early teams &mdash; inquire.</p>
+<h3>Need it set up for you?</h3>
+<p>Get OpenOSINT wired into your stack in 3&ndash;5 days &mdash; done-for-you, fully async, no calls.</p>
+<p><b>&rarr; <a href="https://tommasodev.gumroad.com/l/osint-mcp-setup-sprint" target="_blank" rel="noopener">Book the Setup Sprint &rarr; $350 (founding price, first 5 teams)</a></b></p>
+<p style="margin-top:6px;">&rarr; Or email <a href="mailto:commercial@openosint.tech">commercial@openosint.tech</a> &middot; <a href="https://www.linkedin.com/company/openosintoss" target="_blank" rel="noopener">LinkedIn</a></p>
+<p><em>For authorised use only. See <a href="https://github.com/OpenOSINT/OpenOSINT/blob/main/DISCLAIMER.md" target="_blank" rel="noopener">DISCLAIMER.md</a>.</em></p>
+<p style="margin-top:14px;padding-top:14px;border-top:1px solid #ccc;">Need something more bespoke? I also build custom OSINT integrations wired into your SOC, fraud, threat-intel, or AI-agent stack &mdash; you bring the data sources and compliance requirements, I deliver a working, maintainable integration. <a href="mailto:commercial@openosint.tech?subject=OpenOSINT%20Custom%20Integration" style="color:#000;font-weight:bold;">Get in touch &rarr;</a></p>
+</div>
+
+<h2 id="resources">RESOURCES</h2>
+<div class="indent">
+<p><a href="/free-prompts/?utm_source=site&amp;utm_medium=resources&amp;utm_campaign=free_starter"><b>Free AI OSINT Prompt Starter Set</b></a> &mdash; 5 structured prompts that make ChatGPT and Claude collect real data instead of hallucinating. Free PDF, instant download. <a href="/prompt-pack.html" style="color:#9fb0c3;">Full 30+ pack ($29) &#8599;</a></p>
 </div>
 
 <h2 id="commercial">FOR TEAMS &amp; ORGANIZATIONS</h2>
@@ -569,34 +615,6 @@ $ pip install -e .</pre>
 <p>OpenOSINT is proudly sponsored by <b><a href="https://www.ip2location.com" target="_blank" rel="noopener sponsored">IP2Location</a></b> (IP Geolocation &amp; Threat Intelligence category) and <b><a href="https://www.rapidproxy.io/?ref=openosint" target="_blank" rel="noopener sponsored">RapidProxy</a></b> (Residential Proxies category).</p>
 <p>Featured Integration sponsorships are available for two open categories: <b>breach/compromised-credential data</b> and <b>email/identity lookup</b>. One vendor per category — exclusive placement in the README, docs, CLI banner, and Web UI.</p>
 <p>&rarr; <a href="/sponsors.html"><b>Full media kit and pricing</b></a> &mdash; <a href="https://opencollective.com/openosint_oss" target="_blank" rel="noopener">Open Collective</a> &mdash; <a href="mailto:commercial@openosint.tech?subject=OpenOSINT%20Sponsorship%20Inquiry">commercial@openosint.tech</a></p>
-</div>
-
-<h2 id="services">SERVICES</h2>
-<div class="indent">
-<p>OpenOSINT is free and MIT-licensed. The following is an optional paid setup service offered by the maintainer.</p>
-<p><b>OSINT-MCP Setup Sprint</b> &mdash; done-for-you installation and configuration of an autonomous OSINT-MCP pipeline on your environment. Fully async, no calls required.</p>
-<p><b>Includes:</b></p>
-<ul>
-<li>Pre-configured OpenOSINT setup tailored to your stack (Claude Code, Claude Desktop, or any MCP client)</li>
-<li>API keys wired in &mdash; Shodan, VirusTotal, IP2Location, HaveIBeenPwned, and others as needed</li>
-<li>One investigation workflow built around your use case</li>
-<li>Written step-by-step setup guide + screen-recorded walkthrough</li>
-<li>1-page runbook</li>
-<li>Async email support for 7 days</li>
-</ul>
-<p><b>Delivery:</b> 3&ndash;5 days, fully async.</p>
-<p><b>For:</b> SOC analysts &middot; threat-intel teams &middot; fraud/AML &middot; pentesters &middot; OSINT investigators</p>
-<p><b>Founding pricing</b> available for early teams &mdash; inquire.</p>
-<h3>Need it set up for you?</h3>
-<p>Get OpenOSINT wired into your stack in 3&ndash;5 days &mdash; done-for-you, fully async, no calls.</p>
-<p><b>&rarr; <a href="https://tommasodev.gumroad.com/l/osint-mcp-setup-sprint" target="_blank" rel="noopener">Book the Setup Sprint &rarr; $350 (founding price, first 5 teams)</a></b></p>
-<p style="margin-top:6px;">&rarr; Or email <a href="mailto:commercial@openosint.tech">commercial@openosint.tech</a> &middot; <a href="https://www.linkedin.com/company/openosintoss" target="_blank" rel="noopener">LinkedIn</a></p>
-<p><em>For authorised use only. See <a href="https://github.com/OpenOSINT/OpenOSINT/blob/main/DISCLAIMER.md" target="_blank" rel="noopener">DISCLAIMER.md</a>.</em></p>
-</div>
-
-<h2 id="resources">RESOURCES</h2>
-<div class="indent">
-<p><a href="/free-prompts/?utm_source=site&amp;utm_medium=resources&amp;utm_campaign=free_starter"><b>Free AI OSINT Prompt Starter Set</b></a> &mdash; 5 structured prompts that make ChatGPT and Claude collect real data instead of hallucinating. Free PDF, instant download. <a href="/prompt-pack.html" style="color:#9fb0c3;">Full 30+ pack ($29) &#8599;</a></p>
 </div>
 
 <hr>


### PR DESCRIPTION
## Summary
- Move SERVICES (Setup Sprint) and RESOURCES up next to PROMPT PACK on the homepage, grouping all revenue CTAs right after the value-prop description instead of near the page bottom.
- Remove "MCP integration"/"MCP-native" feature-framing copy from the homepage consulting callout, one blog article's anchor text, the blog index meta description/teaser, and README's custom-integrations blurb. Technical MCP docs (parameters, setup instructions, MCP Registry credit, the dedicated MCP-protocol articles) are untouched.
- Replace the top-of-homepage bespoke-integration masthead (light box, above NAME) with a dark `.oo-cta` product block: live star-count social proof plus Start Free / Prompt Pack $29 / Complete Kit $55 side by side, each with its own `utm_medium=top_hero` for separate attribution. The bespoke-integration offer is preserved, moved into the SERVICES section instead of deleted.

## Test plan
- [ ] Verify openosint.tech reflects changes after GitHub Pages rebuilds
- [ ] Confirm top-of-page Gumroad product block renders correctly (dark theme, 3 buttons, stacks on mobile)
- [ ] Confirm "Start free" button links to `/free-prompts/` (not directly to Gumroad)
- [ ] Confirm SERVICES/RESOURCES render correctly in their new position, no orphaned headings
- [ ] Spot-check the two blog copy edits and the README line

🤖 Generated with [Claude Code](https://claude.com/claude-code)