### PR TITLE
feat: add MiniMax provider configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_BASE_URL=http://localhost:4000/v1
 # OPENAI_API_KEY=sk-...
 # OPENAI_MODEL=gpt-4o-mini
+#
+# 3) MiniMax (global or CN endpoint)
+# MINIMAX_API_KEY=your_key
+# MINIMAX_MODEL=MiniMax-M3
+# MINIMAX_REGION=global
 
 # Optional — required to let POST /api/setup be called from a non-localhost
 # caller (e.g. a public web deployment). Leave unset to keep /api/setup
@@ -62,4 +67,3 @@ DATABASE_URL=postgresql://user:pass@host:5432/dbname
 # Required when DATABASE_URL is set.
 # Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 CONFIG_ENCRYPTION_KEY=
-

--- a/openosint/agent.py
+++ b/openosint/agent.py
@@ -7,6 +7,7 @@ Implements the agentic loop using either:
   - A local Ollama model (``provider="ollama"``).
   - Any OpenAI-compatible chat-completions endpoint (``provider="openai"``) —
     LiteLLM, llama-swap, vLLM, LM Studio, etc.
+  - MiniMax text models on a selected global or CN endpoint (``provider="minimax"``).
 
 All agents share the same ``run()`` interface and return an ``AgentResponse``.
 No manual JSON parsing.  The model issues hard stops when it needs a tool,
@@ -849,6 +850,10 @@ class OpenAICompatibleAgent:
     tool_call → execute real binary → feed real output back → loop until done.
     """
 
+    provider_name = "OpenAI-compatible"
+    api_key_env = "OPENAI_API_KEY"
+    retry_command = "openosint --provider openai"
+
     def __init__(
         self,
         model: str = "gpt-4o-mini",
@@ -858,7 +863,7 @@ class OpenAICompatibleAgent:
         self.model = model
         self.base_url = base_url
         # Many local servers ignore the key, but the SDK requires a non-empty string.
-        self.api_key = api_key or os.environ.get("OPENAI_API_KEY", "") or "sk-no-key-required"
+        self.api_key = api_key or os.environ.get(self.api_key_env, "") or "sk-no-key-required"
         self.history: list[dict[str, Any]] = []
 
     def clear_history(self) -> None:
@@ -893,7 +898,7 @@ class OpenAICompatibleAgent:
                 error=(
                     "The 'openai' Python library is not installed.\n"
                     "Install it with:  pip install openai\n\n"
-                    "Then retry:  openosint --provider openai"
+                    f"Then retry:  {self.retry_command}"
                 ),
             )
 
@@ -918,7 +923,8 @@ class OpenAICompatibleAgent:
                     return AgentResponse(
                         content="",
                         error=(
-                            f"OpenAI endpoint returned no choices from {self.base_url}. "
+                            f"{self.provider_name} endpoint returned no choices "
+                            f"from {self.base_url}. "
                             "Verify the model supports tool/function calling."
                         ),
                     )
@@ -932,21 +938,60 @@ class OpenAICompatibleAgent:
             return AgentResponse(
                 content="",
                 error=(
-                    f"Authentication failed for the OpenAI-compatible endpoint at "
-                    f"{self.base_url}.  Check your API key (OPENAI_API_KEY)."
+                    f"Authentication failed for the {self.provider_name} endpoint at "
+                    f"{self.base_url}.  Check your API key ({self.api_key_env})."
                 ),
             )
         except openai.APIConnectionError:
             return AgentResponse(
                 content="",
                 error=(
-                    f"[ERROR] Cannot reach the OpenAI-compatible server at {self.base_url}\n\n"
-                    "Verify the base URL is correct and the server is running, e.g.:\n"
-                    "  openosint --provider openai \\\n"
-                    "    --openai-base-url http://localhost:4000/v1 \\\n"
-                    "    --openai-model gpt-4o-mini"
+                    f"[ERROR] Cannot reach the {self.provider_name} server at {self.base_url}\n\n"
+                    "Verify the base URL is correct and the server is running, then retry:\n"
+                    f"  {self.retry_command}"
                 ),
             )
         except Exception as exc:
             logger.exception("Unexpected error in OpenAI-compatible agent loop.")
             return AgentResponse(content="", error=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# MiniMax agent
+# ---------------------------------------------------------------------------
+
+
+MINIMAX_MODELS = ("MiniMax-M3", "MiniMax-M2.7")
+MINIMAX_BASE_URLS = {
+    "global": "https://api.minimax.io/v1",
+    "cn": "https://api.minimaxi.com/v1",
+}
+
+
+class MiniMaxAgent(OpenAICompatibleAgent):
+    """OpenAI-compatible MiniMax agent with built-in model and region settings."""
+
+    provider_name = "MiniMax"
+    api_key_env = "MINIMAX_API_KEY"
+    retry_command = "openosint --provider minimax"
+
+    def __init__(
+        self,
+        model: str = MINIMAX_MODELS[0],
+        region: str = "global",
+        api_key: str | None = None,
+    ) -> None:
+        try:
+            base_url = MINIMAX_BASE_URLS[region]
+        except KeyError as exc:
+            supported_regions = ", ".join(MINIMAX_BASE_URLS)
+            raise ValueError(
+                f"Unsupported MiniMax region {region!r}; choose one of: {supported_regions}."
+            ) from exc
+
+        super().__init__(
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+        )
+        self.region = region

--- a/openosint/cli.py
+++ b/openosint/cli.py
@@ -31,6 +31,7 @@ import logging  # noqa: E402
 import os  # noqa: E402
 import sys  # noqa: E402
 
+from openosint.agent import MINIMAX_BASE_URLS, MINIMAX_MODELS  # noqa: E402
 from openosint.json_output import format_tool_result  # noqa: E402
 from openosint.proxy import (  # noqa: E402
     ProxyConfigError,
@@ -116,6 +117,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "  openosint --json email target@example.com\n"
             "  openosint --provider ollama                 # use local Ollama\n"
             "  openosint --provider ollama --ollama-model mistral\n"
+            "  openosint --provider minimax --minimax-region cn\n"
             "  openosint --proxy socks5://user:pass@host:1080 email target@example.com\n"
             "  openosint proxy-test                        # verify the configured proxy\n"
             "\n"
@@ -156,7 +158,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--provider",
         type=str,
         default="anthropic",
-        choices=["anthropic", "ollama", "openai"],
+        choices=["anthropic", "ollama", "openai", "minimax"],
         help="AI provider for the interactive REPL (default: anthropic).",
     )
     parser.add_argument(
@@ -203,6 +205,29 @@ def _build_parser() -> argparse.ArgumentParser:
             "API key for the OpenAI-compatible endpoint.  "
             "Falls back to $OPENAI_API_KEY (local servers may ignore it)."
         ),
+    )
+    parser.add_argument(
+        "--minimax-model",
+        type=str,
+        default=os.environ.get("MINIMAX_MODEL", MINIMAX_MODELS[0]),
+        choices=MINIMAX_MODELS,
+        metavar="MODEL",
+        help="MiniMax model (default: MiniMax-M3). Used when --provider minimax.",
+    )
+    parser.add_argument(
+        "--minimax-region",
+        type=str,
+        default=os.environ.get("MINIMAX_REGION", "global"),
+        choices=tuple(MINIMAX_BASE_URLS),
+        metavar="REGION",
+        help="MiniMax endpoint region: global or cn (default: global).",
+    )
+    parser.add_argument(
+        "--minimax-api-key",
+        type=str,
+        default=None,
+        metavar="KEY",
+        help="MiniMax API key. Falls back to MINIMAX_API_KEY.",
     )
     parser.add_argument(
         "--no-pdf",
@@ -1073,6 +1098,9 @@ async def _async_main() -> None:
             openai_base_url=getattr(args, "openai_base_url", "http://localhost:8080/v1"),
             openai_model=getattr(args, "openai_model", "gpt-4o-mini"),
             openai_api_key=getattr(args, "openai_api_key", None),
+            minimax_model=getattr(args, "minimax_model", MINIMAX_MODELS[0]),
+            minimax_region=getattr(args, "minimax_region", "global"),
+            minimax_api_key=getattr(args, "minimax_api_key", None),
             is_pdf_disabled=getattr(args, "is_pdf_disabled", False),
         )
         await repl.run()

--- a/openosint/repl.py
+++ b/openosint/repl.py
@@ -9,6 +9,7 @@ Usage:
     openosint                                  # Anthropic Claude (default)
     openosint --provider ollama                # local Ollama model
     openosint --provider ollama --ollama-model mistral
+    openosint --provider minimax --minimax-region cn
     openosint --no-pdf                         # disable PDF export
 """
 
@@ -31,7 +32,13 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 
 from openosint import __version__
-from openosint.agent import OllamaAgent, OpenAICompatibleAgent, OpenOSINTAgent
+from openosint.agent import (
+    MINIMAX_MODELS,
+    MiniMaxAgent,
+    OllamaAgent,
+    OpenAICompatibleAgent,
+    OpenOSINTAgent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +108,8 @@ def _print_banner(provider: str, model: str) -> None:
         provider_info = f"[dim]Provider: Ollama ({model})[/]"
     elif provider == "openai":
         provider_info = f"[dim]Provider: OpenAI-compatible ({model})[/]"
+    elif provider == "minimax":
+        provider_info = f"[dim]Provider: MiniMax ({model})[/]"
     else:
         provider_info = f"[dim]Provider: Anthropic ({model})[/]"
 
@@ -216,6 +225,8 @@ def _print_config(
     ollama_host: str,
     is_pdf_disabled: bool,
     openai_base_url: str = "",
+    minimax_region: str = "",
+    minimax_base_url: str = "",
 ) -> None:
     masked = ("*" * 20 + api_key[-6:]) if api_key and len(api_key) > 6 else "not set"
     rows = [
@@ -226,6 +237,9 @@ def _print_config(
         rows.append(f"[bold]API Key:[/]  {masked}")
     elif provider == "openai":
         rows.append(f"[bold]Endpoint:[/] {openai_base_url}")
+    elif provider == "minimax":
+        rows.append(f"[bold]Region:[/]   {minimax_region}")
+        rows.append(f"[bold]Endpoint:[/] {minimax_base_url}")
     else:
         rows.append(f"[bold]Ollama:[/]   {ollama_host}")
     rows += [
@@ -282,6 +296,9 @@ class OpenOSINTRepl:
         openai_base_url: str = "http://localhost:8080/v1",
         openai_model: str = "gpt-4o-mini",
         openai_api_key: str | None = None,
+        minimax_model: str = MINIMAX_MODELS[0],
+        minimax_region: str = "global",
+        minimax_api_key: str | None = None,
         is_pdf_disabled: bool = False,
     ) -> None:
         self._api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
@@ -291,9 +308,11 @@ class OpenOSINTRepl:
         self._openai_base_url = openai_base_url
         self._openai_model = openai_model
         self._openai_api_key = openai_api_key
+        self._minimax_region = minimax_region
+        self._minimax_base_url = ""
         self._is_pdf_disabled = is_pdf_disabled
 
-        self._agent: OpenOSINTAgent | OllamaAgent | OpenAICompatibleAgent
+        self._agent: OpenOSINTAgent | OllamaAgent | OpenAICompatibleAgent | MiniMaxAgent
         if provider == "ollama":
             self._agent = OllamaAgent(
                 model=ollama_model,
@@ -307,6 +326,14 @@ class OpenOSINTRepl:
                 api_key=openai_api_key,
             )
             self._display_model = openai_model
+        elif provider == "minimax":
+            self._agent = MiniMaxAgent(
+                model=minimax_model,
+                region=minimax_region,
+                api_key=minimax_api_key,
+            )
+            self._minimax_base_url = self._agent.base_url
+            self._display_model = minimax_model
         else:
             self._agent = OpenOSINTAgent(api_key=self._api_key)
             self._display_model = "claude-sonnet-4-20250514"
@@ -455,6 +482,8 @@ class OpenOSINTRepl:
                         self._ollama_host,
                         self._is_pdf_disabled,
                         self._openai_base_url,
+                        self._minimax_region,
+                        self._minimax_base_url,
                     )
                     continue
 

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,106 @@
+"""Tests for the dedicated MiniMax provider configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestMiniMaxAgentConfiguration:
+    def test_default_configuration_uses_global_m3(self):
+        from openosint.agent import MINIMAX_BASE_URLS, MINIMAX_MODELS, MiniMaxAgent
+
+        agent = MiniMaxAgent()
+
+        assert agent.model == MINIMAX_MODELS[0]
+        assert agent.region == "global"
+        assert agent.base_url == MINIMAX_BASE_URLS["global"]
+
+    def test_cn_region_uses_cn_endpoint_and_selected_model(self):
+        from openosint.agent import MINIMAX_BASE_URLS, MINIMAX_MODELS, MiniMaxAgent
+
+        agent = MiniMaxAgent(model=MINIMAX_MODELS[1], region="cn")
+
+        assert agent.model == MINIMAX_MODELS[1]
+        assert agent.region == "cn"
+        assert agent.base_url == MINIMAX_BASE_URLS["cn"]
+
+    def test_api_key_uses_minimax_environment_variable(self, monkeypatch):
+        from openosint.agent import MiniMaxAgent
+
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+        monkeypatch.setenv("OPENAI_API_KEY", "generic-key-should-not-win")
+
+        agent = MiniMaxAgent()
+
+        assert agent.api_key == "test-minimax-key"
+
+    def test_unknown_region_is_rejected(self):
+        from openosint.agent import MiniMaxAgent
+
+        with pytest.raises(ValueError, match="Unsupported MiniMax region"):
+            MiniMaxAgent(region="unknown")
+
+
+class TestMiniMaxCliConfiguration:
+    def test_provider_and_defaults_are_available(self):
+        from openosint.agent import MINIMAX_BASE_URLS, MINIMAX_MODELS
+        from openosint.cli import _build_parser
+
+        args = _build_parser().parse_args(["--provider", "minimax"])
+
+        assert args.provider == "minimax"
+        assert args.minimax_model == MINIMAX_MODELS[0]
+        assert args.minimax_region == "global"
+        assert tuple(MINIMAX_BASE_URLS) == ("global", "cn")
+
+    def test_model_region_and_key_flags_are_forwarded(self):
+        from openosint.agent import MINIMAX_MODELS
+        from openosint.cli import _build_parser
+
+        args = _build_parser().parse_args(
+            [
+                "--provider",
+                "minimax",
+                "--minimax-model",
+                MINIMAX_MODELS[1],
+                "--minimax-region",
+                "cn",
+                "--minimax-api-key",
+                "test-key",
+            ]
+        )
+
+        assert args.minimax_model == MINIMAX_MODELS[1]
+        assert args.minimax_region == "cn"
+        assert args.minimax_api_key == "test-key"
+
+    def test_environment_defaults_are_used(self, monkeypatch):
+        from openosint.agent import MINIMAX_MODELS
+        from openosint.cli import _build_parser
+
+        monkeypatch.setenv("MINIMAX_MODEL", MINIMAX_MODELS[1])
+        monkeypatch.setenv("MINIMAX_REGION", "cn")
+
+        args = _build_parser().parse_args([])
+
+        assert args.minimax_model == MINIMAX_MODELS[1]
+        assert args.minimax_region == "cn"
+
+
+class TestMiniMaxReplWiring:
+    def test_repl_constructs_minimax_agent_with_selected_configuration(self):
+        from openosint.agent import MINIMAX_BASE_URLS, MINIMAX_MODELS, MiniMaxAgent
+        from openosint.repl import OpenOSINTRepl
+
+        repl = OpenOSINTRepl(
+            provider="minimax",
+            minimax_model=MINIMAX_MODELS[1],
+            minimax_region="cn",
+            minimax_api_key="test-key",
+        )
+
+        assert isinstance(repl._agent, MiniMaxAgent)
+        assert repl._agent.model == MINIMAX_MODELS[1]
+        assert repl._agent.region == "cn"
+        assert repl._agent.base_url == MINIMAX_BASE_URLS["cn"]
+        assert repl._display_model == MINIMAX_MODELS[1]


### PR DESCRIPTION
Reason: Add first-class MiniMax model and regional endpoint selection to the executable agent.

## Summary

- Adds a dedicated `minimax` provider with `MiniMax-M3` and `MiniMax-M2.7` model selection.
- Adds built-in `global` and `cn` endpoint selection with dedicated model, region, and API-key settings.
- Wires MiniMax through the CLI and REPL while reusing the existing agent tool loop.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] New integration (new OSINT tool or external API)
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Other (describe below)

## Test plan

- `pytest -q tests/test_minimax_provider.py` (8 passed)
- `pytest -q --ignore=tests/test_playbooks.py` (485 passed)
- Focused `ruff check` for the changed Python files (passed)
- `ruff format --check` for the changed Python files (passed)
- Full `pytest -q` reached 513 passed; 5 existing playbook tests require unavailable optional command-line tools
- Required secret scan (passed)

## Checklist

- [ ] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, and `CLAUDE.md`
- [ ] README and docs updated where applicable
- [ ] If adding an integration: the new tool is registered in `agent.py`, `mcp_server.py`, `cli.py`, `repl.py`, and `web_server.py`
- [x] `.env.example` updated for the new environment variables
- [x] No secrets or API keys committed
