### PR TITLE
fix: preserve structured OSINT search results

### DIFF
--- a/openosint/extractors.py
+++ b/openosint/extractors.py
@@ -16,7 +16,7 @@ from typing import Callable
 
 from openosint.correlation import Entity, EntityType, Relationship, make_entity
 
-ExtractorFn = Callable[[str, Entity], tuple[list[Entity], list[Relationship]]]
+ExtractorFn = Callable[[str | dict | list, Entity], tuple[list[Entity], list[Relationship]]]
 
 # ---------------------------------------------------------------------------
 # Shared regex patterns
@@ -455,7 +455,7 @@ def _extract_abuseipdb(raw: str, seed: Entity) -> tuple[list[Entity], list[Relat
     return entities, relationships
 
 
-def _extract_footprint(raw: str, seed: Entity) -> tuple[list[Entity], list[Relationship]]:
+def _extract_footprint(raw: str | dict | list, seed: Entity) -> tuple[list[Entity], list[Relationship]]:
     """Extract URL and domain entities from search_footprint output."""
     entities: list[Entity] = []
     relationships: list[Relationship] = []
@@ -464,6 +464,24 @@ def _extract_footprint(raw: str, seed: Entity) -> tuple[list[Entity], list[Relat
         return entities, relationships
 
     seen_domains: set[str] = set()
+
+    if isinstance(raw, dict):
+        for url in raw.get("discovered_urls", []):
+            if url.startswith("http"):
+                e = make_entity(EntityType.URL, url, 0.75, "search_footprint")
+                entities.append(e)
+                relationships.append(
+                    Relationship(seed, e, "found_via_serp", "search_footprint", 0.75)
+                )
+        for domain in raw.get("seen_domains", []):
+            if domain and "." in domain and domain not in seen_domains:
+                seen_domains.add(domain)
+                e = make_entity(EntityType.DOMAIN, domain, 0.7, "search_footprint")
+                entities.append(e)
+                relationships.append(
+                    Relationship(seed, e, "footprint_on", "search_footprint", 0.7)
+                )
+        return entities, relationships
 
     for line in raw.splitlines():
         stripped = line.strip()

--- a/openosint/playbooks/runner.py
+++ b/openosint/playbooks/runner.py
@@ -140,27 +140,28 @@ def _missing_requirements(tool: str) -> tuple[list[str], str | None]:
 # ---------------------------------------------------------------------------
 
 
-async def _run_step(tool: str, target: str) -> tuple[StepState, str]:
+async def _run_step(tool: str, target: str) -> tuple[StepState, object]:
     """Run a single tool step.  Never raises."""
     missing, _note = _missing_requirements(tool)
     if missing:
         return StepState.NOT_CONFIGURED, ""
 
     try:
-        output: str = await TOOL_MAP[tool](target)  # type: ignore[call-arg]
+        output = await TOOL_MAP[tool](target)  # type: ignore[call-arg]
     except Exception as exc:
         logger.debug("Step '%s' raised: %s", tool, exc)
         return StepState.ERROR, str(exc)
 
-    if not output or not output.strip():
+    if not output:
+        return StepState.EMPTY, ""
+    if isinstance(output, str) and not output.strip():
         return StepState.EMPTY, ""
 
-    # Detect self-caught errors returned as plain strings — check invalid
-    # input first (more specific) before the generic error prefix check.
-    if _looks_like_invalid_input(output):
-        return StepState.INVALID_INPUT, output
-    if _looks_like_tool_error(output):
-        return StepState.ERROR, output
+    if isinstance(output, str):
+        if _looks_like_invalid_input(output):
+            return StepState.INVALID_INPUT, output
+        if _looks_like_tool_error(output):
+            return StepState.ERROR, output
 
     return StepState.SUCCESS, output
 
@@ -306,7 +307,27 @@ def _format_subdomains(output: str) -> str:
     return "\n".join(t)
 
 
-def _format_footprint(output: str) -> str:
+def _format_footprint(output: object) -> str:
+    if isinstance(output, dict):
+        if output.get("error"):
+            return f"```\n{output['error']}\n```"
+            
+        urls = output.get("discovered_urls", [])
+        if not urls:
+            return "No results found."
+            
+        rendered: list[str] = []
+        if output.get("queries"):
+            rendered.append(f"**Queries Run: {output.get('queries', 0)}**\n")
+            
+        for i, url in enumerate(urls, 1):
+            rendered.append(f"{i}. **[{url}]({url})**")
+            
+        return "\n".join(rendered).rstrip()
+        
+    if not isinstance(output, str):
+        return f"```\n{output}\n```"
+
     query_blocks: list[tuple[str, list[dict]]] = []
     current_query: str | None = None
     current_results: list[dict] = []
@@ -369,7 +390,7 @@ def _format_footprint(output: str) -> str:
     if not query_blocks:
         return f"```\n{output.strip()}\n```"
 
-    rendered: list[str] = []
+    rendered = []
     counter = 0
     for query_text, results in query_blocks:
         rendered.append(f"**Query: `{query_text}`**")
@@ -489,29 +510,33 @@ def _format_holehe(output: str) -> str:
     return "\n".join(found)
 
 
-def _format_step_output(tool_name: str, output: str) -> str:
+def _format_step_output(tool_name: str, output: object) -> str:
     """Dispatch to a tool-specific Markdown formatter, falling back to fenced code."""
     if tool_name == "search_whois":
-        return _format_whois(output)
+        return _format_whois(output)  # type: ignore
     if tool_name == "search_dns":
-        return _format_dns(output)
+        return _format_dns(output)  # type: ignore
     if tool_name == "generate_dorks":
-        return _format_dorks(output)
+        return _format_dorks(output)  # type: ignore
     if tool_name == "search_domain":
-        return _format_subdomains(output)
+        return _format_subdomains(output)  # type: ignore
     if tool_name == "search_footprint":
         return _format_footprint(output)
     if tool_name == "search_ip":
-        return _format_ip_info(output)
+        return _format_ip_info(output)  # type: ignore
     if tool_name == "search_virustotal":
-        return _format_virustotal(output)
+        return _format_virustotal(output)  # type: ignore
     if tool_name == "search_paste":
-        return _format_paste(output)
+        return _format_paste(output)  # type: ignore
     if tool_name == "search_username":
-        return _format_username(output)
+        return _format_username(output)  # type: ignore
     if tool_name == "search_email":
-        return _format_holehe(output)
-    return f"```\n{output.strip()}\n```"
+        return _format_holehe(output)  # type: ignore
+    
+    if isinstance(output, str):
+        return f"```\n{output.strip()}\n```"
+    import json
+    return f"```json\n{json.dumps(output, indent=2)}\n```"
 
 
 # ---------------------------------------------------------------------------
@@ -659,7 +684,7 @@ def _build_observations(
 def _build_summary(
     target: str,
     recipe_target_type: str,
-    step_results: list[tuple[str, str, StepState, str]],
+    step_results: list[tuple[str, str, StepState, object]],
 ) -> str:
     from openosint.correlation import EntityType, make_entity
     from openosint.extractors import EXTRACTOR_REGISTRY
@@ -772,7 +797,7 @@ def _build_report(
     target_type: str,
     target: str,
     date_str: str,
-    step_results: list[tuple[str, str, StepState, str]],
+    step_results: list[tuple[str, str, StepState, object]],
     summary: str,
     observations: str,
     steps_map: dict[str, tuple[str, str]],

--- a/openosint/tools/search_dorks_live.py
+++ b/openosint/tools/search_dorks_live.py
@@ -101,7 +101,7 @@ async def run_dorks_live_osint(
     timeout_seconds: int = _DEFAULT_TIMEOUT,
     *,
     api_keys: dict[str, str] | None = None,
-) -> str:
+) -> list[dict] | str:
     """
     Execute Google dork queries for *target* via the Bright Data SERP API.
 
@@ -114,8 +114,8 @@ async def run_dorks_live_osint(
 
     Returns
     -------
-    str
-        Formatted results or descriptive error message.
+    list[dict] | str
+        Structured JSON results or descriptive error message.
     """
     _k = api_keys or {}
     api_key = _k.get("BRIGHTDATA_API_KEY") or os.environ.get("BRIGHTDATA_API_KEY", "")
@@ -133,38 +133,36 @@ async def run_dorks_live_osint(
     dorks = _DORK_TEMPLATES[:max_dorks]
     logger.info("Starting live dork search for '%s' (%d dorks)", target, len(dorks))
 
-    lines = [f"Bright Data live dork search for '{target}' ({len(dorks)} queries):\n"]
     error_count = 0
+    structured_results = []
 
     for template in dorks:
         query = template.format(target=target)
         google_url = _build_google_url(query)
-        lines.append(f"[+] Dork: {query}")
+        
+        query_data = {
+            "query": query,
+            "results": [],
+            "error": None
+        }
+
         try:
             data = await asyncio.to_thread(
                 _fetch_serp, google_url, api_key, zone, timeout_seconds
             )
             results = _extract_organic(data)
             if results:
-                for r in results:
-                    lines.append(f"    Title:   {r['title']}")
-                    lines.append(f"    URL:     {r['url']}")
-                    if r["snippet"]:
-                        lines.append(f"    Snippet: {r['snippet'][:200]}")
-                    lines.append("")
-            else:
-                lines.append("    (no organic results)")
-                lines.append("")
+                query_data["results"] = results
         except OSINTError as exc:
             error_count += 1
             logger.warning("SERP dork failed: %s", exc)
-            lines.append(f"    (error: {exc})")
-            lines.append("")
+            query_data["error"] = str(exc)
         except Exception as exc:
             error_count += 1
             logger.exception("Unexpected error during live dork execution.")
-            lines.append(f"    (internal error: {exc})")
-            lines.append("")
+            query_data["error"] = f"internal error: {exc}"
+            
+        structured_results.append(query_data)
 
     if error_count == len(dorks):
         return (
@@ -173,4 +171,4 @@ async def run_dorks_live_osint(
         )
 
     logger.info("Live dork search complete for: %s", target)
-    return "\n".join(lines)
+    return structured_results

--- a/openosint/tools/search_footprint.py
+++ b/openosint/tools/search_footprint.py
@@ -164,7 +164,7 @@ async def run_footprint_osint(
     timeout_seconds: int = _DEFAULT_TIMEOUT,
     *,
     api_keys: dict[str, str] | None = None,
-) -> str:
+) -> dict | str:
     """
     Collect a target's public search-engine footprint via the Bright Data SERP API.
 
@@ -189,8 +189,8 @@ async def run_footprint_osint(
 
     Returns
     -------
-    str
-        Formatted footprint report with graph-compatible URL lines, or a
+    dict | str
+        Structured footprint report with graph-compatible URL lines, or a
         descriptive error message.
     """
     _k = api_keys or {}
@@ -220,51 +220,56 @@ async def run_footprint_osint(
         "Starting footprint search for '%s' (type=%s, %d queries)", target, kind, len(queries)
     )
 
-    lines: list[str] = [
-        f"[Footprint] {target}  |  type: {kind}  |  "
-        f"{len(queries)} quer{'y' if len(queries) == 1 else 'ies'}\n"
-    ]
-
     seen_urls: set[str] = set()
     seen_domains: set[str] = set()
     discovered_urls: list[str] = []
     error_count = 0
+    
+    structured_results = {
+        "target": target,
+        "target_type": kind,
+        "queries": [],
+        "discovered_urls": [],
+        "seen_domains": []
+    }
 
     for i, query in enumerate(queries, start=1):
         google_url = _build_google_url(query)
-        lines.append(f"[+] Query {i}/{len(queries)}: {query}")
+        
+        query_data = {
+            "query": query,
+            "results": [],
+            "error": None
+        }
+
         try:
             data = await asyncio.to_thread(
                 _fetch_serp, google_url, api_key, zone, timeout_seconds
             )
             results = _extract_organic(data)
             if results:
+                query_data["results"] = results
                 for r in results:
                     url_key = r["url"].rstrip("/")
                     if url_key in seen_urls:
                         continue
                     seen_urls.add(url_key)
                     discovered_urls.append(r["url"])
-                    lines.append(f"    {r['rank']}. {r['title']}")
-                    lines.append(f"       URL:     {r['url']}")
-                    if r["display_url"]:
-                        lines.append(f"       Display: {r['display_url']}")
-                    if r["snippet"]:
-                        lines.append(f"       Snippet: {r['snippet']}")
-                    lines.append("")
-            else:
-                lines.append("    (no organic results)")
-                lines.append("")
+                    
+                    domain = _domain_from_url(r["url"])
+                    if domain and domain not in seen_domains:
+                        seen_domains.add(domain)
+
         except OSINTError as exc:
             error_count += 1
             logger.warning("Footprint SERP query failed: %s", exc)
-            lines.append(f"    (error: {exc})")
-            lines.append("")
+            query_data["error"] = str(exc)
         except Exception as exc:
             error_count += 1
             logger.exception("Unexpected error in footprint SERP query.")
-            lines.append(f"    (internal error: {exc})")
-            lines.append("")
+            query_data["error"] = f"internal error: {exc}"
+            
+        structured_results["queries"].append(query_data)
 
     if error_count == len(queries):
         return (
@@ -272,15 +277,8 @@ async def run_footprint_osint(
             "Check BRIGHTDATA_API_KEY and BRIGHTDATA_SERP_ZONE."
         )
 
-    # Append graph-compatible summary lines (parsed by _extract_footprint in extractors.py)
-    if discovered_urls:
-        lines.append("── Discovered URLs " + "─" * 42)
-        for url in discovered_urls:
-            lines.append(f"[Footprint] URL: {url}")
-            domain = _domain_from_url(url)
-            if domain and domain not in seen_domains:
-                seen_domains.add(domain)
-                lines.append(f"[Footprint] Domain: {domain}")
+    structured_results["discovered_urls"] = discovered_urls
+    structured_results["seen_domains"] = list(seen_domains)
 
     logger.info(
         "Footprint search complete for '%s': %d URLs, %d domains",
@@ -288,4 +286,4 @@ async def run_footprint_osint(
         len(discovered_urls),
         len(seen_domains),
     )
-    return "\n".join(lines)
+    return structured_results

--- a/openosint/web/index.html
+++ b/openosint/web/index.html
@@ -568,7 +568,7 @@
                     </div>
                     <div x-show="!part.collapsed && part.output"
                          class="border-t border-app bg-app px-3 py-2 max-h-64 overflow-y-auto">
-                      <template x-for="(line, li) in (part.output || '').split('\n')" :key="li">
+                      <template x-for="(line, li) in (typeof part.output === 'string' ? part.output : JSON.stringify(part.output, null, 2)).split('\n')" :key="li">
                         <div class="font-mono text-xs leading-relaxed whitespace-pre-wrap break-all"
                              :class="lineClass(line)"
                              x-text="line || ' '"></div>

--- a/openosint/web/static/entity-graph.js
+++ b/openosint/web/static/entity-graph.js
@@ -464,14 +464,25 @@ const _REGISTRY = {
     const inferredType = _inferType(target);
     const rootId = `${inferredType}:${target.toLowerCase().trim()}`;
 
-    _vals(output, '\\[Footprint\\] URL:').forEach(url => {
-      const n = _node('social_account', url, { source: 'footprint' });
-      nodes.push(n); edges.push(_edge(rootId, n.id, 'links to'));
-    });
-    _vals(output, '\\[Footprint\\] Domain:').forEach(d => {
-      const n = _node('domain', d, {});
-      nodes.push(n); edges.push(_edge(rootId, n.id, 'found at'));
-    });
+    if (typeof output === 'object' && output !== null) {
+      (output.discovered_urls || []).forEach(url => {
+        const n = _node('social_account', url, { source: 'footprint' });
+        nodes.push(n); edges.push(_edge(rootId, n.id, 'links to'));
+      });
+      (output.seen_domains || []).forEach(d => {
+        const n = _node('domain', d, {});
+        nodes.push(n); edges.push(_edge(rootId, n.id, 'found at'));
+      });
+    } else {
+      _vals(output, '\\[Footprint\\] URL:').forEach(url => {
+        const n = _node('social_account', url, { source: 'footprint' });
+        nodes.push(n); edges.push(_edge(rootId, n.id, 'links to'));
+      });
+      _vals(output, '\\[Footprint\\] Domain:').forEach(d => {
+        const n = _node('domain', d, {});
+        nodes.push(n); edges.push(_edge(rootId, n.id, 'found at'));
+      });
+    }
     return { nodes, edges };
   },
 

--- a/openosint/web_server.py
+++ b/openosint/web_server.py
@@ -668,7 +668,7 @@ def _select_chat_backend(req: "ChatRequest") -> str:
 # ---------------------------------------------------------------------------
 
 
-async def _run_tool(tool_name: str, tool_input: str, timeout: int = 120) -> str:
+async def _run_tool(tool_name: str, tool_input: str, timeout: int = 120) -> str | list | dict:
     if tool_name not in _RUNNERS:
         return f"Unknown tool: {tool_name}"
     if not str(tool_input).strip():
@@ -797,7 +797,7 @@ async def _stream_claude(messages: list[dict]) -> AsyncIterator[dict]:
                                 {
                                     "type": "tool_result",
                                     "tool_use_id": current_block["id"],
-                                    "content": result,
+                                    "content": result if isinstance(result, str) else json.dumps(result),
                                 }
                             )
 
@@ -909,7 +909,7 @@ async def _stream_ollama(
             elapsed = round(time.monotonic() - t0, 2)
 
             yield {"type": "tool_result", "tool": tool_name, "output": result, "elapsed": elapsed}
-            tool_results_for_next.append({"role": "tool", "content": result})
+            tool_results_for_next.append({"role": "tool", "content": result if isinstance(result, str) else json.dumps(result)})
 
         msgs = (
             msgs
@@ -1025,7 +1025,7 @@ async def _stream_openai(
                 {
                     "role": "tool",
                     "tool_call_id": tc.get("id", ""),
-                    "content": result,
+                    "content": result if isinstance(result, str) else json.dumps(result),
                 }
             )
 
@@ -1351,7 +1351,8 @@ def create_app() -> FastAPI:
             try:
                 result = await _RUNNERS[tool_name](input, timeout)
                 elapsed = round(time.monotonic() - start, 2)
-                for line in result.splitlines():
+                result_str = result if isinstance(result, str) else json.dumps(result)
+                for line in result_str.splitlines():
                     if await request.is_disconnected():
                         return
                     yield {"data": json.dumps({"line": line, "done": False})}

--- a/tests/test_brightdata.py
+++ b/tests/test_brightdata.py
@@ -98,9 +98,10 @@ class TestSearchDorksLive:
 
             result = await run_dorks_live_osint("john doe", max_dorks=1)
 
-        assert "John Doe LinkedIn" in result
-        assert "linkedin.com/in/johndoe" in result
-        assert "Software engineer" in result
+        assert len(result) == 1
+        assert result[0]["results"][0]["title"] == "John Doe LinkedIn"
+        assert result[0]["results"][0]["url"] == "https://linkedin.com/in/johndoe"
+        assert "Software engineer" in result[0]["results"][0]["snippet"]
 
     async def test_success_result_contains_dork_header(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "test-key")
@@ -112,7 +113,8 @@ class TestSearchDorksLive:
 
             result = await run_dorks_live_osint("example.com", max_dorks=1)
 
-        assert "[+] Dork:" in result
+        assert len(result) == 1
+        assert "site:" in result[0]["query"] or "example.com" in result[0]["query"]
 
     async def test_no_organic_results_shows_placeholder(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "test-key")
@@ -124,7 +126,8 @@ class TestSearchDorksLive:
 
             result = await run_dorks_live_osint("target", max_dorks=1)
 
-        assert "no organic results" in result
+        assert len(result) == 1
+        assert result[0]["results"] == []
 
     async def test_organic_link_field_used_as_url(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "test-key")
@@ -143,7 +146,8 @@ class TestSearchDorksLive:
 
             result = await run_dorks_live_osint("target", max_dorks=1)
 
-        assert "primary-link.com" in result
+        assert len(result) == 1
+        assert result[0]["results"][0]["url"] == "https://primary-link.com"
 
     async def test_request_uses_format_raw_not_json(self, monkeypatch):
         """Verify the outbound request body uses format=raw to prevent envelope wrapping."""

--- a/tests/test_footprint.py
+++ b/tests/test_footprint.py
@@ -136,7 +136,7 @@ class TestSearchFootprintEntityDetection:
 
             result = await run_footprint_osint("user@example.com", max_queries=1)
 
-        assert "type: email" in result
+        assert result["target_type"] == "email"
 
     async def test_output_shows_detected_entity_type_username(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "k")
@@ -147,7 +147,7 @@ class TestSearchFootprintEntityDetection:
 
             result = await run_footprint_osint("johndoe99", max_queries=1)
 
-        assert "type: username" in result
+        assert result["target_type"] == "username"
 
     async def test_full_name_detected_as_person(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "k")
@@ -158,7 +158,7 @@ class TestSearchFootprintEntityDetection:
 
             result = await run_footprint_osint("John Doe", max_queries=1)
 
-        assert "type: person" in result
+        assert result["target_type"] == "person"
 
 
 # ---------------------------------------------------------------------------
@@ -176,8 +176,7 @@ class TestSearchFootprintResults:
 
             result = await run_footprint_osint("john doe", max_queries=1)
 
-        assert "John Doe — LinkedIn" in result
-        assert "linkedin.com/in/johndoe" in result
+        assert any("linkedin.com/in/johndoe" in url for url in result["discovered_urls"])
 
     async def test_deduplicates_urls_across_queries(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "k")
@@ -188,12 +187,7 @@ class TestSearchFootprintResults:
 
             result = await run_footprint_osint("john doe", max_queries=2)
 
-        # linkedin.com/in/johndoe should appear only once in graph lines
-        if "── Discovered URLs" in result:
-            graph_section = result.split("── Discovered URLs")[1]
-        else:
-            graph_section = result
-        assert graph_section.count("https://linkedin.com/in/johndoe") == 1
+        assert result["discovered_urls"].count("https://linkedin.com/in/johndoe") == 1
 
     async def test_no_organic_shows_placeholder(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "k")
@@ -204,7 +198,7 @@ class TestSearchFootprintResults:
 
             result = await run_footprint_osint("john doe", max_queries=1)
 
-        assert "no organic results" in result
+        assert result["discovered_urls"] == []
 
     async def test_request_uses_format_raw_and_parsed_light(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "k")
@@ -321,8 +315,8 @@ class TestSearchFootprintGraphLines:
 
             result = await run_footprint_osint("john doe", max_queries=1)
 
-        assert "[Footprint] URL: https://linkedin.com/in/johndoe" in result
-        assert "[Footprint] URL: https://github.com/johndoe" in result
+        assert "https://linkedin.com/in/johndoe" in result["discovered_urls"]
+        assert "https://github.com/johndoe" in result["discovered_urls"]
 
     async def test_domain_lines_emitted(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "k")
@@ -333,8 +327,8 @@ class TestSearchFootprintGraphLines:
 
             result = await run_footprint_osint("john doe", max_queries=1)
 
-        assert "[Footprint] Domain: linkedin.com" in result
-        assert "[Footprint] Domain: github.com" in result
+        assert "linkedin.com" in result["seen_domains"]
+        assert "github.com" in result["seen_domains"]
 
     async def test_no_graph_lines_when_no_results(self, monkeypatch):
         monkeypatch.setenv("BRIGHTDATA_API_KEY", "k")
@@ -345,7 +339,7 @@ class TestSearchFootprintGraphLines:
 
             result = await run_footprint_osint("john doe", max_queries=1)
 
-        assert "[Footprint] URL:" not in result
+        assert result["discovered_urls"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -13,6 +13,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
+import pytest
+
+@pytest.fixture(autouse=True)
+def mock_shutil_which(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda b: f"/usr/bin/{b}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One to three sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New integration (new OSINT tool or external API)
- [ ] Refactor / internal improvement
- [ ] Documentation update
- [ ] Other (describe below)

## Test plan

<!-- Steps to verify this change works correctly. -->

## Checklist

- [ ] All tests pass (`pytest`)
- [ ] Version bumped consistently across `pyproject.toml`, `openosint/__init__.py`, `README.md`, and `CLAUDE.md`
- [ ] README and docs updated where applicable
- [ ] If adding an integration: the new tool is registered in `agent.py`, `mcp_server.py`, `cli.py`, `repl.py`, and `web_server.py`
- [ ] `.env.example` updated for any new environment variable
- [ ] No secrets or API keys committed
